### PR TITLE
보드 초기화 동작과 스테이지 초안

### DIFF
--- a/MineSweeper.vcxproj
+++ b/MineSweeper.vcxproj
@@ -27,6 +27,7 @@
     <ClCompile Include="src\Combats\ShootTheMonster.cpp" />
     <ClCompile Include="src\MineField.cpp" />
     <ClCompile Include="src\MineSweeper.cpp" />
+    <ClCompile Include="src\Stage.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\Block.h" />
@@ -39,6 +40,7 @@
     <ClInclude Include="src\CommonDeclarations.h" />
     <ClInclude Include="src\MineField.h" />
     <ClInclude Include="src\resource.h" />
+    <ClInclude Include="src\Stage.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>

--- a/MineSweeper.vcxproj.filters
+++ b/MineSweeper.vcxproj.filters
@@ -39,6 +39,9 @@
     <ClCompile Include="src\Combats\ShootTheMonster.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="src\Stage.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\MineField.h">
@@ -69,6 +72,9 @@
       <Filter>헤더 파일</Filter>
     </ClInclude>
     <ClInclude Include="src\Combats\ShootTheMonster.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="src\Stage.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/Block.cpp
+++ b/src/Block.cpp
@@ -1,7 +1,6 @@
 #include "Block.h"
 
-std::shared_ptr<_block> Block::Create(ScenePtr bg, int x, int y)
-{
+std::shared_ptr<_block> Block::Create(ScenePtr bg, int x, int y) {
 	// 새로운 칸 객체 생성
 	std::shared_ptr<_block> newBlock(new _block(bg, x, y));
 	return newBlock;
@@ -9,7 +8,7 @@ std::shared_ptr<_block> Block::Create(ScenePtr bg, int x, int y)
 
 _block::_block(ScenePtr bg, int x, int y) {
 	blockObject = Object::create(BlockResource::BLOCK, bg, x, y);
-	
+
 	//blockObject->hide(); //디버그용
 	isFlagImage = false;
 }

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -1,9 +1,11 @@
 #include "Board.h"
 
 Board::Board(ScenePtr bg) {
+	status = Status::Playing;
+
 	background = bg;
 	// 행, 열 테스트 값
-	int row = 10, col = 10;
+	int row = BOARD_SIZE, col = BOARD_SIZE;
 
 	// 지뢰 생성 테스트
 	field.Resize(row, col);
@@ -29,19 +31,27 @@ Board::Board(ScenePtr bg) {
 	testObject->show();
 	testObject->setOnMouseCallback([&](auto, auto, auto, auto)->bool {
 
-		Combat* testCombat = new ShootTheMonster(background);
+		Combat* testCombat = new DiceRolling(background);
 		testCombat->EnterBattle();
 		return true;
 		});
-		*/
+	*/
+
 	// 핸드 컨트롤 객체
 	handObject = Object::create(HandResource::PICKAX, background, 430, 430);
 	handObject->setOnMouseCallback([&](auto object, int x, int y, auto action)->bool {
 		HandChange();
 		return true;
 		});
-}
 
+	// ** 디버그용 ** 리셋 버튼 생성 및 마우스 콜백 등록
+	resetButton = Object::create(BlockResource::BLOCK, background, 0, 0);
+	resetButton->setOnMouseCallback([&](auto object, int x, int y, auto action)->bool {
+		status = Status::Clear;
+		RefreshBoard(status, background);
+		return true;
+		});
+}
 
 void Board::HandChange() {
 	if (hand == Hand::Pickax) {
@@ -53,3 +63,54 @@ void Board::HandChange() {
 		hand = Hand::Pickax;
 	}
 }
+
+void Board::RefreshBoard(Status stat, ScenePtr ch) {
+	// 이 함수가 불리는 경우는 반드시 새 게임이 시작되는 상으로 Playing 상황에서는 불릴 수 없다.
+	if (stat == Status::Playing) {
+		std::cout << "예상치 못한 보드 초기화가 발생했습니다." << std::endl;
+		exit(1);
+	}
+
+	int row = BOARD_SIZE;
+	int col = BOARD_SIZE;
+
+	// cell 초기화
+	// cells 데이터 삭제
+	for (int i = 0; i < row; i++) {
+		cells[i].clear();
+	}
+	cells.clear();
+
+	// ch, int, row는 게임 클리어 시에 갱신된다.
+	/*
+	if (stat == Status::Clear) {
+		// ch를 갱신하는 방식은 임의로 새로운 씬을 생성하는 것으로 함. 이미지만을 변경하는 방식도 고려 가능
+		ch = Scene::create("배경", BoardResource::BACKGROUND);
+		row += 5;
+		col += 5;
+	}
+	*/
+
+	/*
+	// 게임 오버 시에는 같은 스테이지를 다시 플레이하거나 타이틀로 돌아가는 방식도 고려 가능
+	if (stat == Status::GameOver) {
+	}
+	*/
+
+	// field 초기화
+	field.Resize(row, col);
+	field.MountMine();
+	field.setAdjacentNum();
+	field.Print();
+
+	// cells에 새 데이터 저장
+	for (int i = 0; i < row; i++) {
+		std::vector<CellPtr> cellRow;
+		for (int j = 0; j < col; j++) {
+			CellPtr cell = Cell::Create(ch, field[i][j], i, j, &hand);
+			cellRow.push_back(cell);
+		}
+		cells.push_back(cellRow);
+	}
+}
+

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -5,7 +5,7 @@ Board::Board(ScenePtr bg) {
 
 	background = bg;
 	// 행, 열 테스트 값
-	int row = BOARD_SIZE, col = BOARD_SIZE;
+	row = BOARD_SIZE, col = BOARD_SIZE;
 
 	// 지뢰 생성 테스트
 	field.Resize(row, col);
@@ -48,7 +48,7 @@ Board::Board(ScenePtr bg) {
 	resetButton = Object::create(BlockResource::BLOCK, background, 0, 0);
 	resetButton->setOnMouseCallback([&](auto object, int x, int y, auto action)->bool {
 		status = Status::Clear;
-		RefreshBoard(status, background);
+		RefreshBoard();
 		return true;
 		});
 }
@@ -64,15 +64,12 @@ void Board::HandChange() {
 	}
 }
 
-void Board::RefreshBoard(Status stat, ScenePtr ch) {
+void Board::RefreshBoard() {
 	// 이 함수가 불리는 경우는 반드시 새 게임이 시작되는 상으로 Playing 상황에서는 불릴 수 없다.
-	if (stat == Status::Playing) {
+	if (status == Status::Playing) {
 		std::cout << "예상치 못한 보드 초기화가 발생했습니다." << std::endl;
 		exit(1);
 	}
-
-	int row = BOARD_SIZE;
-	int col = BOARD_SIZE;
 
 	// cell 초기화
 	// cells 데이터 삭제
@@ -81,15 +78,12 @@ void Board::RefreshBoard(Status stat, ScenePtr ch) {
 	}
 	cells.clear();
 
-	// ch, int, row는 게임 클리어 시에 갱신된다.
-	/*
-	if (stat == Status::Clear) {
+	// int, row는 게임 클리어 시에 갱신된다.
+	if (status == Status::Clear) {
 		// ch를 갱신하는 방식은 임의로 새로운 씬을 생성하는 것으로 함. 이미지만을 변경하는 방식도 고려 가능
-		ch = Scene::create("배경", BoardResource::BACKGROUND);
 		row += 5;
 		col += 5;
 	}
-	*/
 
 	/*
 	// 게임 오버 시에는 같은 스테이지를 다시 플레이하거나 타이틀로 돌아가는 방식도 고려 가능
@@ -107,7 +101,7 @@ void Board::RefreshBoard(Status stat, ScenePtr ch) {
 	for (int i = 0; i < row; i++) {
 		std::vector<CellPtr> cellRow;
 		for (int j = 0; j < col; j++) {
-			CellPtr cell = Cell::Create(ch, field[i][j], i, j, &hand);
+			CellPtr cell = Cell::Create(background, field[i][j], i, j, &hand);
 			cellRow.push_back(cell);
 		}
 		cells.push_back(cellRow);

--- a/src/Board.h
+++ b/src/Board.h
@@ -29,6 +29,9 @@ private:
 	// 배경
 	ScenePtr background;
 
+	// 보드의 가로 세로 크기
+	int row, col;
+
 	// 칸 객체를 저장하는 2차원 vector
 	std::vector<std::vector<CellPtr>> cells;
 
@@ -55,5 +58,5 @@ public:
 	void HandChange();
 
 	// 보드를 초기화하는 함수
-	void RefreshBoard(Status stat, ScenePtr ch);
+	void RefreshBoard();
 };

--- a/src/Board.h
+++ b/src/Board.h
@@ -1,10 +1,10 @@
 /*
 * Board
-* 
+*
 * 지뢰찾기 게임을 진행할 판을 구현하는 클래스.
 * 각 스테이지마다 정해진 개수의 칸을 가지며
-* 지뢰의 위치는 매 판마다 무직위적이어야 한다. 
-* 
+* 지뢰의 위치는 매 판마다 무직위적이어야 한다.
+*
 */
 
 #pragma once
@@ -41,11 +41,19 @@ private:
 	// 현재 사용중인 도구의 상태를 표시하기 위한 객체
 	ObjectPtr handObject;
 
+	// 현재 보드의 상황을 나타내는 변수
+	Status status;
+
+	// **디버그용** 보드를 초기화 하기 위한 버튼 객체
+	ObjectPtr resetButton;
+
 public:
 
 	Board(ScenePtr bg);
 
 	// 핸드컨트롤 객체의 상태를 바꾸는 함수
 	void HandChange();
-};
 
+	// 보드를 초기화하는 함수
+	void RefreshBoard(Status stat, ScenePtr ch);
+};

--- a/src/Cell.cpp
+++ b/src/Cell.cpp
@@ -19,7 +19,7 @@ _cell::_cell(ScenePtr bg, FieldData fieldData, int x, int y, Hand* handPtr) {
 	ChangeNumImage(fieldData);
 
 	//°¢°¢ÀÇ Ä­ÀÇ À§¸¦ µ¤À» ºí·° °´Ã¼ »ý¼º
-	BlockPtr block = Block::Create(bg, x, y);
+	block = Block::Create(bg, x, y);
 
 	//ºí·°°´Ã¼¿¡ ´ëÇÑ MouseCallback ÇÔ¼ö Á¤ÀÇ
 	MakeBlockCallback(block);
@@ -30,7 +30,7 @@ _cell::_cell(ScenePtr bg, FieldData fieldData, int x, int y, Hand* handPtr) {
 
 void _cell::ChangeNumImage(FieldData fieldData) {
 
-	switch (fieldData.cellValue){
+	switch (fieldData.cellValue) {
 		// Áö·ÚÄ­ÀÏ °æ¿ì
 	case CellValue::Mine:
 		cellObject->setImage(CellResource::MINE);
@@ -45,7 +45,7 @@ void _cell::ChangeNumImage(FieldData fieldData) {
 
 	switch (fieldData.num) {
 
-	// ¼ýÀÚÀÏ °æ¿ì
+		// ¼ýÀÚÀÏ °æ¿ì
 	case 1:
 		cellObject->setImage(CellResource::ONE);
 		break;
@@ -71,7 +71,7 @@ void _cell::ChangeNumImage(FieldData fieldData) {
 		cellObject->setImage(CellResource::EIGHT);
 		break;
 
-	// ºóÄ­ÀÏ °æ¿ì
+		// ºóÄ­ÀÏ °æ¿ì
 	default:
 		break;
 	}
@@ -86,7 +86,7 @@ void _cell::MakeBlockCallback(BlockPtr block) {
 			block->ChangeBlockImage();
 		}
 		return true;
-	});
+		});
 }
 
 void _cell::BreakBlock(BlockPtr block) {

--- a/src/Cell.h
+++ b/src/Cell.h
@@ -1,10 +1,10 @@
 /*
 * Cell
-* 
-* 보드에 나열될 칸 클래스. 
+*
+* 보드에 나열될 칸 클래스.
 * 보드 객체에서 팩토리 메서드로 셀을 생성할 때
-* 해당 셀이 지뢰일지, 그렇지 않을지 결정한다. 
-* 지뢰 여부는 생성시에 결정되지만 숫자는 이후에 정해진다. 
+* 해당 셀이 지뢰일지, 그렇지 않을지 결정한다.
+* 지뢰 여부는 생성시에 결정되지만 숫자는 이후에 정해진다.
 */
 
 #pragma once
@@ -18,8 +18,8 @@ using namespace bangtal;
 class _cell;
 
 /*
-* _cell 객체를 shared_ptr로 생성하여 
-* CellPtr을 반환하는 함수. 
+* _cell 객체를 shared_ptr로 생성하여
+* CellPtr을 반환하는 함수.
 */
 namespace Cell {
 	std::shared_ptr<_cell> Create(ScenePtr bg, FieldData fieldData, int row, int col, Hand* handPtr);
@@ -33,6 +33,9 @@ private:
 	// 방탈 오브젝트 객체
 	ObjectPtr cellObject;
 
+	// 셀을 덮고 있는 Block 객체
+	BlockPtr block;
+
 	// 셀이 드러난 상태인지를 나타내는 플래그
 	bool isOpened = false;
 
@@ -40,7 +43,7 @@ private:
 	Hand* handPtr;
 
 	/*
-	* _cell의 생성자는 숨겨져 있고 Cell::create()를 사용해 생성해야 한다. 
+	* _cell의 생성자는 숨겨져 있고 Cell::create()를 사용해 생성해야 한다.
 	*/
 	_cell(ScenePtr bg, FieldData fieldData, int x, int y, Hand* handPtr);
 

--- a/src/CommonDeclarations.h
+++ b/src/CommonDeclarations.h
@@ -1,11 +1,20 @@
 /*
 * CommonDeclarations.h
-* 
-* 코드 내에서 사용하는 매크로와 전역 변수들을 정의하는 헤더. 
-* 타이머 시간, 좌표값 간격 등을 정의한다. 
+*
+* 코드 내에서 사용하는 매크로와 전역 변수들을 정의하는 헤더.
+* 타이머 시간, 좌표값 간격 등을 정의한다.
 */
 
 #pragma once
+
+/*
+* 스테이지 진행 상황을 정의하는 enum.
+*/
+enum Status {
+	Playing,
+	GameOver,
+	Clear
+};
 
 /*
 * 지뢰와 숫자, 탈출구를 정의하는 enum.
@@ -17,7 +26,7 @@ enum CellValue {
 };
 
 /*
-* 아이템을 정의하는 enum. 
+* 아이템을 정의하는 enum.
 */
 enum ItemValue {
 	AddLife,
@@ -38,8 +47,8 @@ enum class Hand {
 
 
 /*
-* 한 cell에 담긴 정보를 전달할 때 사용할 클래스. 
-* 여러 정보를 동시에 전달할 때 사용한다. 
+* 한 cell에 담긴 정보를 전달할 때 사용할 클래스.
+* 여러 정보를 동시에 전달할 때 사용한다.
 */
 struct FieldData {
 	// 지뢰, 탈출구, 빈칸 여부
@@ -54,3 +63,6 @@ struct FieldData {
 
 // 셀 하나 한 변의 픽셀 길이
 constexpr auto CELL_SIZE = 30;
+
+// 보드의 가로 세로 크기
+constexpr auto BOARD_SIZE = 10;

--- a/src/Stage.cpp
+++ b/src/Stage.cpp
@@ -1,0 +1,35 @@
+#include "Stage.h"
+
+Stage::Stage(ScenePtr ch, Status stat) {
+	// 스테이지는 시작 화면과 게임 화면을 가진다
+	// ch.시작화면
+	// 마우스 콜백 -> ch.배경화면
+	// 보드는 ch.배경화면으로 변경될 때 보인다.
+	// 보드가 초기화되면 스테이지 진행 상황은 Playing으로 초기화된다.
+}
+
+void Stage::EventHandler() {
+	// Playing -> 이벤트 없음
+	// GameOver -> 보드 초기화
+	// Claer -> 다음 스테이지
+}
+
+void Stage::setChapterStatus() {
+	// 스테이지 진행 상태 변경
+	// 보드 생성, 초기화 -> Playing
+	// 게임 오버 조건 (목숨이 다한 경우, 지뢰를 밟은 경우 -> 차이 없지 않나?) -> GameOver
+	// 게임 클리어 조건 (지뢰를 제외한 모든 칸을 열고 목숨이 남은 경우) -> Clear 
+}
+
+void Stage::getChapterStatus() {
+	// 스테이지 진행 상태 확인
+}
+
+void Stage::RestartStage() {
+	// 씬 초기화 -> 보드 초기화
+}
+
+void Stage::NextStage() {
+	// 씬 변경 -> 씬 생성? 배경 사진만 바꾸고 보드 초기화? (후자가 나은 듯)
+}
+

--- a/src/Stage.h
+++ b/src/Stage.h
@@ -1,0 +1,39 @@
+#pragma once
+
+/*
+*
+*
+*/
+
+#pragma once
+
+#include <iostream>
+#include <bangtal>
+#include "CommonDeclarations.h"
+#include "Board.h"
+
+using namespace bangtal;
+
+class Stage {
+private:
+	ScenePtr chapter;
+	//Board board;
+
+public:
+	Stage(ScenePtr ch, Status stat);
+
+	// 스테이지 진행 상황 변경시 적절한 이벤트를 발생하는 함수
+	void EventHandler(); // 이벤트는 어디에서 발생할지?( 누가 이벤트 변수를 변경하나?)
+
+	// 스테이지 진행 상황을 변경하는 함수
+	void setChapterStatus();
+
+	// 스테이지 진행 상황을 확인하는 함수
+	void getChapterStatus();
+
+	// 게임 오버 시 해당 스테이지를 다시 시작하는 함수
+	void RestartStage();
+
+	// 스테이지 클리어 시 다음 스테이지로 넘어가는 함수
+	void NextStage();
+};


### PR DESCRIPTION
1. 스테이지 진행 상황을 나타내는 전역 변수가 선언되었습니다. row와 col 크기를 저장하는 전역 변수가 선언되었습니다.
2. Cell이 생성될 때 Block을 클래스 멤버에 저장합니다.
3. Board를 초기화하는 함수가 선언되었습니다. 게임 진행 상황을 나타내는 stat과 현재 씬을 인자로 받습니다. 게임 진행 상황에 따라 같은 크기나 혹은 더 큰 크기의 보드를 생성합니다.
   디버깅을 위해 Board를 초기화하는 버튼이 추가되었습니다. 보드 초기화 동작을 확인하는 것으로 이후 게임에서는 게임 오버나 게임 클리어 시에 보드가 초기화되어야 합니다.
   다만 보드의 크기가 커질 때 동작하지 못하는 문제가 있어 수정해야 합니다.
4. 주석으로만 구성된 스테이지의 초안 파일이 추가되었습니다. 이후 보드에서의 동작을 받아 처리하는 동작이 주를 이룰 것입니다.