### PR TITLE
빈칸 확장 메서드 추가

### DIFF
--- a/src/BlockBreakHandler.cpp
+++ b/src/BlockBreakHandler.cpp
@@ -28,6 +28,30 @@ void BlockBreakHandler::CheckNewCellOpened() {
 					std::cout << "row: " << i << ", col: " << j << 
 						"\ncellValue: " << field[i][j].cellValue << ", num: " << field[i][j].num << ", itemValue: " << field[i][j].itemValue << std::endl;
 					isCellOpen[i][j] = true;
+					//  빈 칸 확장 메서드
+					// 새로 열린 칸이 빈칸이라면 이하의 빈칸 확장 과정을 진행한다.
+					if (field[i][j].cellValue == CellValue::Empty && field[i][j].num == 0) { // itemValue와 관련된 조건 추가 필요!
+						// k는 확장될 칸의 row 위치이다.
+						for (int k = i - 1; k <= i + 1; k++) {
+							// 위치가 범위를 벗어나면 진행하지 않는다.
+							if (k < 0 || k >= row) {
+								continue;
+							}
+							else {
+								// l은 확장될 칸의 col 위치이다.
+								for (int l = j - 1; l <= j + 1; l++) {
+									// 위치가 범위를 벗어나면 진행하지 않는다.
+									if (l < 0 || l >= col) {
+										continue;
+									}
+									// 아직 열리지 않은 칸이고 숫자 칸이라면 연다.
+									else if (cells[k][l]->getIsOpened() == false && field[k][l].cellValue == CellValue::Empty) {
+										cells[k][l]->BreakBlock(cells[k][l]->getBlock());
+									}
+								}
+							}
+						}
+					}
 				}
 			}
 		}

--- a/src/Cell.cpp
+++ b/src/Cell.cpp
@@ -96,3 +96,7 @@ void _cell::BreakBlock(BlockPtr block) {
 bool _cell::getIsOpened(){
 	return isOpened;
 }
+
+BlockPtr _cell::getBlock() {
+	return block;
+}

--- a/src/Cell.h
+++ b/src/Cell.h
@@ -67,6 +67,11 @@ public:
 	* 현재 cell이 보이는지 여부를 반환하는 함수
 	*/
 	bool getIsOpened();
+
+	/* 
+	* cell을 덮고 있는 block의 BlockPtr을 반환하는 함수
+	*/
+	BlockPtr getBlock();
 };
 
 // _cell에 대한 shared_ptr를 CellPtr로 정한다. 


### PR DESCRIPTION
1. 빈칸 확장 메서드가 추가되었습니다. 선택된 cell이 빈 칸일 경우 cell의 인덱스를 기반으로 상하좌우 및 대각선에 인접한 칸들 중 열리지 않은 숫자칸을 엽니다. 새로 열릴 칸들 중 빈칸이 있으면 이벤트 핸들러에 의해 연쇄적으로 작동합니다.
2. 빈칸 확장 메서드를 위해 cell을 덮고 있는 block을 리턴하는 함수가 Cell 클래스에 추가되었습니다.