### PR TITLE
이벤트 핸들러 구체화 및 스테이지 구현 상세화

### DIFF
--- a/src/BlockBreakHandler.cpp
+++ b/src/BlockBreakHandler.cpp
@@ -117,9 +117,6 @@ void BlockBreakHandler::RefreshBoardStatus(int i, int j) {
 				break;
 			}
 		}
-		if (isCleared == 0) {
-			break;
-		}
 	}
 	// 순회가 끝난 후에도 보드가 Clear조건을 만족하면 보드의 상태를 갱신한다.
 	if (isCleared == 1) {

--- a/src/BlockBreakHandler.cpp
+++ b/src/BlockBreakHandler.cpp
@@ -13,6 +13,18 @@ BlockBreakHandler::BlockBreakHandler(int newRow, int newCol, MineField& newField
 	}
 }
 
+Status BlockBreakHandler::getStatus() {
+	return status;
+}
+
+void BlockBreakHandler::setStatus(Status stat) {
+	status = stat;
+}
+
+void BlockBreakHandler::setLife(int num) {
+	life = num;
+}
+
 void BlockBreakHandler::CheckNewCellOpened() {
 	// 이 타이머가 돌면서 새로 열린 칸이 존재하는지 체크한다. 
 	// REFRESH_TIME을 너무 길게하면 반응성이 떨어지고, 
@@ -26,10 +38,18 @@ void BlockBreakHandler::CheckNewCellOpened() {
 					// 디버그용 출력
 					// 이 부분에 Combat, 또는 빈칸 확장 메서드를 연결할 것
 					std::cout << "row: " << i << ", col: " << j << 
-						"\ncellValue: " << field[i][j].cellValue << ", num: " << field[i][j].num << ", itemValue: " << field[i][j].itemValue << std::endl;
+						"\ncellValue: " << field[i][j].cellValue << ", num: " << field[i][j].num << ", itemValue: " << field[i][j].itemValue << ", life: " << life << std::endl;
 					isCellOpen[i][j] = true;
-					//  빈 칸 확장 메서드
-					// 새로 열린 칸이 빈칸이라면 이하의 빈칸 확장 과정을 진행한다.
+
+					// ** 디버그 용 ** 지뢰 칸이면 목숨을 차감한다.
+					if (field[i][j].cellValue == CellValue::Mine) {
+						life -= 1;
+					}
+
+					// 필요하다면 보드의 상태를 갱신한다.
+					RefreshBoardStatus(i, j);
+					
+					// 필요하다면 빈 칸을 확장해 칸을 연다.
 					ExpandBorder(i, j);
 				}
 			}
@@ -68,6 +88,42 @@ void BlockBreakHandler::ExpandBorder(int i, int j) {
 				}
 			}
 		}
+	}
+}
+
+void BlockBreakHandler::RefreshBoardStatus(int i, int j) {
+	// GameOver
+	// 남은 목숨이 없다면 보드의 상태를 GameOver로 바꾼다.
+	if (life == 0) {
+		status = Status::GameOver;
+	}
+
+	// Escape
+	// 새로 열린 칸이 탈출구이면 보드 상태를 Escape로 바꾼다.
+	if (field[i][j].cellValue == CellValue::Escape) {
+		status = Status::Escape;
+	}
+
+	// Clear
+	// 지뢰 칸을 제외한 모든 칸이 열렸으면 보드 상태를 Clear로 바꾼다.
+	// isCleared는 보드가 Clear조건을 만족함을 나타내는 변수이다. (1 -> 만족, 0 -> 불만족)
+	int isCleared = 1;
+	// 모든 칸을 for loop으로 순회한다.
+	for (int k = 0; (k < row) && (isCleared == 1); k++) {
+		for (int l = 0; (l < col) && (isCleared == 1); l++) {
+			// 지뢰 칸을 제외한 칸 중 열리지 않은 칸이 있다면 순회를 멈춘다.
+			if (field[k][l].cellValue != CellValue::Mine && isCellOpen[k][l] == false) {
+				isCleared = 0;
+				break;
+			}
+		}
+		if (isCleared == 0) {
+			break;
+		}
+	}
+	// 순회가 끝난 후에도 보드가 Clear조건을 만족하면 보드의 상태를 갱신한다.
+	if (isCleared == 1) {
+		status = Status::Clear;
 	}
 }
 

--- a/src/BlockBreakHandler.h
+++ b/src/BlockBreakHandler.h
@@ -25,9 +25,14 @@ using namespace bangtal;
 
 class BlockBreakHandler {
 private:
-
 	// 보드의 크기
 	int row, col;
+
+	// 보드의 상태
+	Status status;
+
+	// 남은 목숨, 보드의 목숨 값을 복사한 것이다. (Board.cpp의 GenerateNewBoard 함수 참고)
+	int life;
 
 	// 셀들이 열렸는지를 체크하는 2차원 벡터
 	std::vector<std::vector<bool>> isCellOpen;
@@ -46,6 +51,21 @@ public:
 	~BlockBreakHandler();
 
 	/*
+	* 보드의 상태를 반환하는 함수
+	*/
+	Status getStatus();
+
+	/*
+	* 보드의 상태를 갱신하는 함수
+	*/
+	void setStatus(Status stat);
+
+	/*
+	* 남은 목숨을 갱신하는 함수
+	*/
+	void setLife(int num);
+
+	/*
 	* 새로 열린 cell이 있는지 확인하는 함수
 	*/
 	void CheckNewCellOpened();
@@ -54,6 +74,11 @@ public:
 	* 빈 칸의 경계에 있는 cell들을 열어 확장하는 함수
 	*/
 	void ExpandBorder(int i, int j);
+
+	/*
+	* 조건을 만족하면 보드의 상태를 갱신하는 함수
+	*/
+	void RefreshBoardStatus(int i, int j);
 
 	/*
 	* cell 확인을 중단하는 함수

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -7,7 +7,6 @@ Board::Board(ScenePtr bg) {
 		exit(1);
 	}
 	boardCount++;
-	status = Status::Clear;
 	background = bg;
 	row = 0, col = 0;
 
@@ -15,14 +14,6 @@ Board::Board(ScenePtr bg) {
 	handObject = Object::create(HandResource::PICKAX, background, 1000, 600);
 	handObject->setOnMouseCallback([&](auto object, int x, int y, auto action)->bool {
 		HandChange();
-		return true;
-		});
-
-	// ** 디버그용 ** 리셋 버튼 생성 및 마우스 콜백 등록
-	resetButton = Object::create(BlockResource::BLOCK, background, 0, 0);
-	resetButton->setOnMouseCallback([&](auto object, int x, int y, auto action)->bool {
-		status = Status::Clear;
-		RefreshBoard(row + 2, col + 4);
 		return true;
 		});
 }
@@ -41,11 +32,11 @@ void Board::HandChange() {
 
 void Board::RefreshBoard(int newRow, int newCol) {
 	// 반드시 클리어 시에만 이 함수를 호출할 것!
-	if (status == Status::Playing) {
+	if (OnBlockBreak->getStatus() == Status::Playing) {
 		std::cout << "클리어되지 못한 보드의 초기화가 발생했습니다." << std::endl;
 		exit(1);
 	}
-	else if (status == Status::GameOver) {
+	else if (OnBlockBreak->getStatus() == Status::GameOver) {
 		std::cout << "게임오버된 보드의 초기화가 발생했습니다." << std::endl;
 		exit(1);
 	}
@@ -54,7 +45,6 @@ void Board::RefreshBoard(int newRow, int newCol) {
 }
 
 void Board::Clear() {
-
 	// cell 초기화
 	// cells 초기화
 	for (int i = 0; i < row; i++) {
@@ -103,9 +93,24 @@ void Board::GenerateNewBoard(int newRow, int newCol) {
 	}
 
 	// 새로 생성된 보드는 플레이 상태로 전환됨.
-	status = Status::Playing;
+	OnBlockBreak->setStatus(Status::Playing);
+
+	// 새로 생성된 보드는 이전의 목숨 갯수를 이어 받음
+	OnBlockBreak->setLife(life);
 
 	// 새 보드 생성이 완료되면 이벤트 핸들러의 루프 시작
 	OnBlockBreak->CheckNewCellOpened();
+}
+
+Status Board::getBoardStatus() {
+	return OnBlockBreak->getStatus();
+}
+
+int Board::getRow() {
+	return row;
+}
+
+int Board::getCol() {
+	return col;
 }
 

--- a/src/Board.h
+++ b/src/Board.h
@@ -18,6 +18,8 @@
 using namespace bangtal;
 
 static int boardCount = 0;
+// ** 디버그를 위해 100으로 초기화 됨 **
+constexpr auto LIFE_COUNT = 100;
 
 /*
 * 지뢰찾기를 진행할 판 클래스
@@ -42,14 +44,11 @@ private:
 	// 현재 사용중인 도구의 상태를 표시하기 위한 객체
 	ObjectPtr handObject;
 
-	// 현재 보드의 상황을 나타내는 변수
-	Status status;
+	// 남은 목숨
+	int life = LIFE_COUNT;
 
 	// 이벤트 핸들러
 	std::shared_ptr<BlockBreakHandler> OnBlockBreak;
-
-	// **디버그용** 보드를 초기화 하기 위한 버튼 객체
-	ObjectPtr resetButton;
 
 public:
 
@@ -66,4 +65,13 @@ public:
 
 	// 보드를 주어진 크기로 새로 생성하는 함수
 	void GenerateNewBoard(int newRow, int newCol);
+
+	// 보드의 상태를 반환하는 함수
+	Status getBoardStatus();
+
+	// 보드의 가로 크기를 반환하는 함수
+	int getRow();
+
+	// 보드의 세로 크기를 반환하는 함수
+	int getCol();
 };

--- a/src/CommonDeclarations.h
+++ b/src/CommonDeclarations.h
@@ -10,9 +10,10 @@
 /*
 * 스테이지 진행 상황을 정의하는 enum.
 */
-enum Status {
+enum class Status {
 	Playing,
 	GameOver,
+	Escape,
 	Clear
 };
 

--- a/src/MineSweeper.cpp
+++ b/src/MineSweeper.cpp
@@ -11,7 +11,7 @@
 
 #include <iostream>
 #include <bangtal>
-#include "Board.h"
+#include "Stage.h"
 #include "resource.h"
 
 int main()
@@ -20,12 +20,11 @@ int main()
 	setGameOption(GameOption::GAME_OPTION_MESSAGE_BOX_BUTTON, false);
 	setGameOption(GameOption::GAME_OPTION_ROOM_TITLE, false);
 
-
-
+	// 게임 타이틀 및 스테이지 별 스크립트를 보이기 위한 방탈 장면
+	ScenePtr frontground = Scene::create("시작 화면", CombatResource::BACKGROUND1);
+	// 게임이 실행되는 방탈 장면
 	ScenePtr background = Scene::create("배경", BoardResource::BACKGROUND);
-	Board board(background);
-	board.GenerateNewBoard(INIT_BOARD_SIZE, INIT_BOARD_SIZE);
+	Stage stage(background, frontground);
 
-	startGame(background);
-
+	startGame(frontground);
 }

--- a/src/Stage.cpp
+++ b/src/Stage.cpp
@@ -1,35 +1,63 @@
 #include "Stage.h"
 
-Stage::Stage(ScenePtr ch, Status stat) {
-	// 스테이지는 시작 화면과 게임 화면을 가진다
-	// ch.시작화면
-	// 마우스 콜백 -> ch.배경화면
-	// 보드는 ch.배경화면으로 변경될 때 보인다.
-	// 보드가 초기화되면 스테이지 진행 상황은 Playing으로 초기화된다.
+Stage::Stage(ScenePtr bg, ScenePtr fg) {
+	background = bg;
+	frontground = fg;
+
+	// 지뢰찾기 보드 생성
+	board = new Board(background);
+	board->GenerateNewBoard(INIT_BOARD_SIZE, INIT_BOARD_SIZE);
+
+	// frontground에서 보여줄 게임 타이틀 및 스테이지 별 스크립트
+	// frontground가 보여줄 스크립트가 끝나면 backround로 입장한다.
+	script = Object::create(CombatResource::MONSTER1, frontground, 0, 0);
+	script->setOnMouseCallback([&](auto object, int x, int y, auto action)->bool {
+		background->enter();
+		return true;
+	});
+
+	// 스테이지의 이벤트 핸들러가 동작한다.
+	EventHandler();
 }
 
 void Stage::EventHandler() {
-	// Playing -> 이벤트 없음
-	// GameOver -> 보드 초기화
-	// Claer -> 다음 스테이지
-}
+	// 타이머가 돌면서 board의 status를 체크한다.
+	boardStatusChecker = Timer::create(REFRESH_TIME);
+	boardStatusChecker->setOnTimerCallback([&](auto)->bool {
+		// Playing -> 이벤트 없음
+		// Claer -> 다음 스테이지
+		if (board->getBoardStatus() == Status::Clear) {
+			NextStage();
+		}
+		// GameOver -> 보드 초기화?
+		if (board->getBoardStatus() == Status::GameOver) {
+			// ** 디버그용 ** 게임 종료
+			endGame();
+		}
+		boardStatusChecker->set(REFRESH_TIME);
+		boardStatusChecker->start();
+		return true;
+		});
 
-void Stage::setChapterStatus() {
-	// 스테이지 진행 상태 변경
-	// 보드 생성, 초기화 -> Playing
-	// 게임 오버 조건 (목숨이 다한 경우, 지뢰를 밟은 경우 -> 차이 없지 않나?) -> GameOver
-	// 게임 클리어 조건 (지뢰를 제외한 모든 칸을 열고 목숨이 남은 경우) -> Clear 
-}
+	boardStatusChecker->start();
 
-void Stage::getChapterStatus() {
-	// 스테이지 진행 상태 확인
-}
-
-void Stage::RestartStage() {
-	// 씬 초기화 -> 보드 초기화
+	// 디버그용 타이머 생성 메세지
+	std::cout << ". . . Now Board Status Chaecker is working . . ." << std::endl;
 }
 
 void Stage::NextStage() {
-	// 씬 변경 -> 씬 생성? 배경 사진만 바꾸고 보드 초기화? (후자가 나은 듯)
+	// 다음 스테이지로 넘어갈 때 보여줄 스크립트를 갱신한다.
+	// script->setImage();
+
+	// 스크립트를 가지고 있는 front 장면으로 입장한다.
+	frontground->enter();
+
+	// 스테이지 레벨을 갱신한다.
+	currentStageLevel++;
+
+	// 다음 지뢰찾기 보드로 갱신한다.
+	int row = board->getRow();
+	int col = board->getCol();
+	board->RefreshBoard(row + 2, col + 4);
 }
 

--- a/src/Stage.cpp
+++ b/src/Stage.cpp
@@ -42,7 +42,7 @@ void Stage::EventHandler() {
 	boardStatusChecker->start();
 
 	// 디버그용 타이머 생성 메세지
-	std::cout << ". . . Now Board Status Chaecker is working . . ." << std::endl;
+	std::cout << ". . . Now Board Status Checker is working . . ." << std::endl;
 }
 
 void Stage::NextStage() {

--- a/src/Stage.h
+++ b/src/Stage.h
@@ -14,26 +14,35 @@
 
 using namespace bangtal;
 
+// 스테이지 갯수
+constexpr auto STAGE_COUNT = 3;
+
 class Stage {
 private:
-	ScenePtr chapter;
-	//Board board;
+	// 지뢰찾기 게임이 진행되는 방탈 장면
+	ScenePtr background;
+
+	// 게임 타이틀 및 스테이지 별 스크립트를 보이기 위한 방탈 장면
+	ScenePtr frontground;
+
+	// 게임 타이틀 및 스테이지 별 스크립트를 나타내는 방탈 오브젝트
+	ObjectPtr script;
+	
+	// 지뢰찾기 보드
+	Board* board;
+
+	// 현재 스테이지 레벨
+	int currentStageLevel = 0;
+
+	// 보드 진행 상황을 체크할 타이머
+	TimerPtr boardStatusChecker;
 
 public:
-	Stage(ScenePtr ch, Status stat);
+	Stage(ScenePtr background, ScenePtr frontground);
 
-	// 스테이지 진행 상황 변경시 적절한 이벤트를 발생하는 함수
-	void EventHandler(); // 이벤트는 어디에서 발생할지?( 누가 이벤트 변수를 변경하나?)
+	// 보드 진행 상황 변경시 적절한 이벤트를 발생하는 함수
+	void EventHandler();
 
-	// 스테이지 진행 상황을 변경하는 함수
-	void setChapterStatus();
-
-	// 스테이지 진행 상황을 확인하는 함수
-	void getChapterStatus();
-
-	// 게임 오버 시 해당 스테이지를 다시 시작하는 함수
-	void RestartStage();
-
-	// 스테이지 클리어 시 다음 스테이지로 넘어가는 함수
+	// 보드 클리어 시 다음 스테이지로 넘어가는 함수
 	void NextStage();
 };


### PR DESCRIPTION
1. Board 헤더 파일을 BlockBreakHandler가 포함했을 때 디버깅 오류가 나는 문제로, 이벤트 햄들러가 보드를 참조할 수 없어 보드의 상태를 나타내는 변수인 status를 Board가 아닌 BlockBreakHandler가 가지도록 구현했습니다.
2. 같은 이유로 남은 목숨을 나타내는 변수가 BlockBreakHandler에 정의되었습니다. 다만 다음 스테이지에서도 이전 스테이지의 목숨과 같은 개수를 가지도록 하기 위해 Board에 저장된 목숨값을 복사받아 저장합니다.
3. BlockBreakHandler 클래스 내에 보드의 상태를 변경하는 함수가 구현되었습니다.
4. 스테이지 클래스의 멤버 함수로 이벤트 핸들러가 구현되었습니다. 보드의 상태에 따라 적절하게 이벤트를 발생시킵니다.
5. 스테이지가 멤버로 frontground를 가집니다. 다음 스테이지로 넘어갈 때 스크립트를 보이는 용도입니다.