### PR TITLE
item 클래스로의 hand 관리 객체 변경

### DIFF
--- a/src/Block.cpp
+++ b/src/Block.cpp
@@ -40,11 +40,12 @@ void _block::ChangeBlockImage() {
 	}
 }
 
-void _block::hideBlock() {
+bool _block::HideBlock() {
 	if (isFlagImage) {
-		return;
+		return false;
 	}
 	blockObject->hide();
+	return true;
 }
 
 void _block::setClickCallback(std::function<bool(ObjectPtr, int, int, MouseAction)> callback) {

--- a/src/Block.h
+++ b/src/Block.h
@@ -57,7 +57,7 @@ public:
 	/*
 	* blockObject를 숨기는 함수
 	*/
-	void hideBlock();
+	bool HideBlock();
 
 	/*
 	* 블럭을 클릭 했을 때를 위한 콜백 함수

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -13,17 +13,12 @@ Board::Board(ScenePtr bg) {
 	// 아이템 클래스의 아이템 객체
 	itemObject = new Item(background);
 
-	// 핸드 컨트롤 객체
-	handObject = Object::create(HandResource::PICKAX, background, 1000, 600);
-
-	// 핸드 컨트롤 객체에 대한 키보드 콜백
+	// 아이템 객체에 대한 키보드 콜백
 	bg -> setOnKeyboardCallback([&](auto bg, auto KeyCode, auto pressed)->bool {
 		if (KeyCode == KeyCode::KEY_1 && pressed == true) {
-			HandChange(Hand::Pickax);
 			itemObject->ChangeHand(0);
 		}
 		if (KeyCode == KeyCode::KEY_2 && pressed == true) {
-			HandChange(Hand::Flag);
 			itemObject->ChangeHand(1);
 		}
 		if (KeyCode == KeyCode::KEY_3 && pressed == true) {
@@ -42,17 +37,6 @@ Board::Board(ScenePtr bg) {
 		});
 }
 
-
-void Board::HandChange(Hand toHand) {
-	if (toHand == Hand::Flag) {
-		handObject->setImage(HandResource::FLAG);
-		hand = Hand::Flag;
-	}
-	else if (toHand == Hand::Pickax) {
-		handObject->setImage(HandResource::PICKAX);
-		hand = Hand::Pickax;
-	}
-}
 
 void Board::RefreshBoard(int newRow, int newCol) {
 	// 반드시 클리어 시에만 이 함수를 호출할 것!
@@ -110,7 +94,21 @@ void Board::GenerateNewBoard(int newRow, int newCol) {
 			// cell의 x, y 좌표 계산. 
 			int x = (640 - col / 2 * CELL_SIZE) + j * CELL_SIZE;
 			int y = (360 + row / 2 * CELL_SIZE) - (i + 1) * CELL_SIZE;
-			CellPtr cell = Cell::Create(background, field[i][j], x, y, &hand);
+			CellPtr cell = Cell::Create(background, field[i][j], x, y);
+			
+
+			// Item의 정보를 셀이 참조하려면 셀을 생성함과 동시에 그 셀의 블록에 대한 마우스 콜백도 함께 생성해야함
+			cell->getBlock()->setClickCallback([=](auto object, int x, int y, auto action)->bool {
+				if (itemObject->getHand() == Hand::Pickax) {
+					cell->BreakBlock();
+				}
+				else if (itemObject->getHand() == Hand::Flag) {
+					cell->getBlock()->ChangeBlockImage();
+				}
+				return true;
+				});
+
+
 			cellRow.push_back(cell);
 		}
 		cells.push_back(cellRow);

--- a/src/Board.h
+++ b/src/Board.h
@@ -46,9 +46,6 @@ private:
 	// 지뢰찾기 판 전체의 데이터를 관리하는 객체
 	MineField field;
 
-	// 현재 사용중인 도구
-	Hand hand = Hand::Pickax;
-
 	// 아이템 객체
 	Item* itemObject;
 
@@ -62,11 +59,7 @@ private:
 	std::shared_ptr<BlockBreakHandler> OnBlockBreak;
 
 public:
-
 	Board(ScenePtr bg);
-
-	// 핸드컨트롤 객체의 상태를 바꾸는 함수
-	void HandChange(Hand toHand);
 
 	// 보드를 주어진 크기로 초기화하고 생성하는 함수
 	void RefreshBoard(int newRow, int newCol);

--- a/src/Cell.cpp
+++ b/src/Cell.cpp
@@ -1,24 +1,18 @@
 #include "Cell.h"
 
-std::shared_ptr<_cell> Cell::Create(ScenePtr bg, FieldData fieldData, int x, int y, Hand* handPtr) {
+std::shared_ptr<_cell> Cell::Create(ScenePtr bg, FieldData fieldData, int x, int y) {
 	// 새로운 칸 객체 생성
-	std::shared_ptr<_cell> newCell(new _cell(bg, fieldData, x, y, handPtr));
+	std::shared_ptr<_cell> newCell(new _cell(bg, fieldData, x, y));
 	return newCell;
 }
 
-_cell::_cell(ScenePtr bg, FieldData fieldData, int x, int y, Hand* handPtr) {
+_cell::_cell(ScenePtr bg, FieldData fieldData, int x, int y) {
 	cellObject = Object::create(CellResource::EMPTY, bg, x, y);
 	// 지뢰 또는 숫자에 따라 이미지 변경
 	ChangeNumImage(fieldData);
 
 	//각각의 칸의 위를 덮을 블럭 객체 생성
 	block = Block::Create(bg, x, y);
-
-	//블럭객체에 대한 MouseCallback 함수 정의
-	MakeBlockCallback();
-
-	//핸드포인터
-	this->handPtr = handPtr;
 }
 
 void _cell::ChangeNumImage(FieldData fieldData) {
@@ -69,23 +63,16 @@ void _cell::ChangeNumImage(FieldData fieldData) {
 	}
 }
 
-void _cell::MakeBlockCallback() {
-	this->block->setClickCallback([=](auto object, int x, int y, auto action)->bool {
-		if (*handPtr == Hand::Pickax) {
-			BreakBlock();
-		}
-		else if (*handPtr == Hand::Flag) {
-			block->ChangeBlockImage();
-		}
-		return true;
-		});
-}
-
 void _cell::BreakBlock() {
-	this->block->hideBlock();
-	isOpened = true;
+	if (this->block->HideBlock()) {
+		isOpened = true;
+	}
 }
 
 bool _cell::getIsOpened(){
 	return isOpened;
+}
+
+BlockPtr _cell::getBlock() {
+	return block;
 }

--- a/src/Cell.h
+++ b/src/Cell.h
@@ -15,15 +15,6 @@
 #include "MineField.h"
 using namespace bangtal;
 
-/*
-* 핸드에 사용하는 enum
-*/
-enum class Hand {
-	//곡괭이
-	Pickax,
-	//깃발
-	Flag,
-};
 
 class _cell;
 
@@ -32,12 +23,12 @@ class _cell;
 * CellPtr을 반환하는 함수.
 */
 namespace Cell {
-	std::shared_ptr<_cell> Create(ScenePtr bg, FieldData fieldData, int x, int y, Hand* handPtr);
+	std::shared_ptr<_cell> Create(ScenePtr bg, FieldData fieldData, int x, int y);
 }
 
 class _cell {
 	// Create 함수가 private에 접근 가능하도록 설정
-	friend std::shared_ptr<_cell> Cell::Create(ScenePtr, FieldData, int, int, Hand*);
+	friend std::shared_ptr<_cell> Cell::Create(ScenePtr, FieldData, int, int);
 
 private:
 	// 방탈 오브젝트 객체
@@ -49,24 +40,16 @@ private:
 	// 셀이 드러난 상태인지를 나타내는 플래그
 	bool isOpened = false;
 
-	// 현재 핸드의 상태를 가리키는 포인터
-	Hand* handPtr;
-
 	/*
 	* _cell의 생성자는 숨겨져 있고 Cell::create()를 사용해 생성해야 한다.
 	*/
-	_cell(ScenePtr bg, FieldData fieldData, int x, int y, Hand* handPtr);
+	_cell(ScenePtr bg, FieldData fieldData, int x, int y);
 
 public:
 	/*
 	* 주어진 숫자로 셀 이미지를 바꾸는 함수
 	*/
 	void ChangeNumImage(FieldData fieldData);
-
-	/*
-	* block객체의 blockObject에 대한 Mousecallback을 만드는 함수
-	*/
-	void MakeBlockCallback();
 
 	/*
 	* 블럭을 부수는 함수
@@ -77,6 +60,11 @@ public:
 	* 현재 cell이 보이는지 여부를 반환하는 함수
 	*/
 	bool getIsOpened();
+
+	/*
+	* 현재 cell과 연결된 블럭을 반환하는 함수
+	*/
+	BlockPtr getBlock();
 };
 
 // _cell에 대한 shared_ptr를 CellPtr로 정한다. 

--- a/src/Item.cpp
+++ b/src/Item.cpp
@@ -29,6 +29,16 @@ Item::Item(ScenePtr bg) {
 	nowUsing = Object::create(HandResource::USING, bg, 340, 0);
 }
 
+Hand Item::getHand() {
+	return hand;
+}
+
 void Item::ChangeHand(int n) {
 	nowUsing->locate(background, 340 + (100 * n), 0);
+	if (n == 0) {
+		hand = Hand::Pickax;
+	}
+	if (n == 1) {
+		hand = Hand::Flag;
+	}
 }

--- a/src/Item.h
+++ b/src/Item.h
@@ -15,12 +15,12 @@
 
 using namespace bangtal;
 
-//enum class Hand {
-//	//곡괭이
-//	Pickax,
-//	//깃발
-//	Flag,
-//};
+enum class Hand {
+	//곡괭이
+	Pickax,
+	//깃발
+	Flag,
+};
 
 class Item {
 private:
@@ -28,16 +28,18 @@ private:
 	ScenePtr background;
 
 	// 현재 핸드 상황
-	//Hand hand = Hand::Pickax;
+	Hand hand = Hand::Pickax;
 
 	// 아이템의 종류를 표현해줄 아이템바 방탈오브젝트
 	ObjectPtr itemBar;
 
 	// 각 아이템의 개수를 확인하기 위한 배열(-1은 무한으로 한다.)
-	int itemNumber[6] = { -1,-1,0,1,2,3 };
+	//int itemNumber[6] = { -1,-1,0,1,2,3 };
+	int itemNumber[2] = { -1,-1 };	//디버그용
 
 	// 각 아이템의 개수를 나타내기 위한 방탈 오브젝트 배열
-	ObjectPtr numObject[6];
+	//ObjectPtr numObject[6];
+	ObjectPtr numObject[2];	//디버그용
 
 	// 현재 사용중인 아이템을 표현해줄 테두리 방탈오브젝트
 	ObjectPtr nowUsing;
@@ -46,7 +48,7 @@ public:
 	Item(ScenePtr bg);
 
 	// 현재 핸드를 확인하는 함수
-	//Hand getHand();
+	Hand getHand();
 
 	// 현재 아이템의 개수를 확인하는 함수
 	//int* getItemNumber();


### PR DESCRIPTION
삭제
Board.h
- 멤버변수 Hand hand
- 멤버변수 ObjectPtr handObject
- ObjectPtr handObject, Hand hand와 관련된 멤버함수 ChangeHand()

Cell.h
- 멤버변수 *Hand HandPtr
- enum class Hand
- 마우스콜백정의 멤버함수 MakeBlockCallback()


추가
Cell.h
- 멤버 함수 getBlock()

Item.h
- enum class Hand
- 멤버 변수 Hand hand (현재 핸드 상황)
- 멤버 함수 Hand getHand() (핸드 상황 반환)


변경
Board.h
- 생성자가 핸드 컨트롤 객체 handObject를 생성하지 않도록 변경
- 키보드 콜백이 itemObject의 hand 상태를 바꿀 수 있도록 변경 
- 멤버함수 GenerateNewBoard()에서 CellPtr cell이 생성됨과 동시에 cell의 멤버변수 Block의 마우스콜백을 함께 정의하도록 변경

Cell.h
- 생성자가 *Hand HandPtr을 인자로 받지않고 마우스콜백을 정의하지 않도록 변경
- 멤버함수 BreakBlock()이 블럭이 깨지지 않아도 isOpened를 true로 바꾸는 문제점 수정
