### PR TITLE
코드 리펙토링, 지뢰 탐지기 작동 구현, Cell 객체의 itemValue 초기화 문제 수정, 획득한 아이템 제거 타이머 구현

### DIFF
--- a/src/Block.cpp
+++ b/src/Block.cpp
@@ -13,7 +13,7 @@ _block::_block(ScenePtr bg, int x, int y) {
 	isFlagImage = false;
 }
 
-void _block::ChangeFlagImage() {
+void _block::ChangeToFlagImage() {
 	if (isFlagImage) {
 		return;
 	}
@@ -21,7 +21,7 @@ void _block::ChangeFlagImage() {
 	isFlagImage = true;
 }
 
-void _block::ChangeEmptyBlockImage() {
+void _block::ChangeToEmptyBlockImage() {
 	if (~isFlagImage) {
 		return;
 	}
@@ -29,7 +29,7 @@ void _block::ChangeEmptyBlockImage() {
 	isFlagImage = false;
 }
 
-void _block::ChangeBlockImage() {
+void _block::SwapBlockImage() {
 	if (isFlagImage) {
 		blockObject->setImage(BlockResource::BLOCK);
 		isFlagImage = false;

--- a/src/Block.h
+++ b/src/Block.h
@@ -42,17 +42,17 @@ public:
 	/*
 	* 깃발로 블럭 이미지를 바꾸는 함수
 	*/
-	void ChangeFlagImage();
+	void ChangeToFlagImage();
 
 	/*
 	* 빈 블럭으로 블럭 이미지를 바꾸는 함수
 	*/
-	void ChangeEmptyBlockImage();
+	void ChangeToEmptyBlockImage();
 
 	/*
 	* 빈 블럭은 깃발블럭으로 깃발블럭은 빈 블럭으로 바꾸는 함수
 	*/
-	void ChangeBlockImage();
+	void SwapBlockImage();
 
 	/*
 	* blockObject를 숨기는 함수

--- a/src/BlockBreakHandler.cpp
+++ b/src/BlockBreakHandler.cpp
@@ -55,6 +55,7 @@ void BlockBreakHandler::CheckNewCellOpened() {
 void BlockBreakHandler::CheckIsItemExist(int curRow, int curCol) {
 	if (field[curRow][curCol].itemValue != ItemValue::None) {
 		item->AddItem(field[curRow][curCol].itemValue);
+		field[curRow][curCol].itemValue = ItemValue::None;
 	}
 }
 

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -12,8 +12,6 @@ Board::Board(ScenePtr bg) {
 
 	// 아이템 클래스의 아이템 객체
 	item = std::make_shared<Item>(background, 3);
-
-	
 }
 
 
@@ -76,28 +74,30 @@ void Board::GenerateNewBoard(int newRow, int newCol) {
 			CellPtr cell = Cell::Create(background, field[i][j], x, y);
 			
 
-			// Item의 정보를 셀이 참조하려면 셀을 생성함과 동시에 그 셀의 블록에 대한 마우스 콜백도 함께 생성해야함
+			// Item의 정보를 셀의 콜백 함수가 참조해야 함
 			cell->getBlock()->setClickCallback([=](auto object, int x, int y, auto action)->bool {
+				switch (item->getCurrentHand())
+				{
+				default:
+					break;
+				}
 				// 핸드가 곡괭이일 경우
-				if (item->getHand() == Hand::Pickax) {
+				if (item->getCurrentHand() == Hand::Pickax) {
 					cell->BreakBlock();
 				}
 				// 핸드가 깃발일경우
-				else if (item->getHand() == Hand::Flag) {
-					cell->getBlock()->ChangeBlockImage();
+				else if (item->getCurrentHand() == Hand::Flag) {
+					cell->getBlock()->SwapBlockImage();
 				}
-				// 핸드가 TNT일 경우
-				else if (item->getHand() == Hand::Detector) {
+				// 현재 선택한 아이템이 detector일 경우
+				else if (item->getCurrentHand() == Hand::Detector) {
 					if (item->getItemCount(Hand::Detector) > 0) {
-						// 이곳에서 아이템의 효과를 호출한다.
-
-						// TNT의 아이템 개수를 1개 줄인다.
+						UseDetector(i, j);
 						item->ReduceItem(Hand::Detector);
-					}
-					else {
-						showMessage("아이템이 없습니다.");
+						item->ChangeHand(Hand::Pickax);
 					}
 				}
+				
 				return true;
 				});
 
@@ -112,6 +112,28 @@ void Board::GenerateNewBoard(int newRow, int newCol) {
 
 	// 새 보드 생성이 완료되면 이벤트 핸들러의 루프 시작
 	OnBlockBreak->CheckNewCellOpened();
+}
+
+void Board::UseDetector(int clickedCellRow, int clickedCellCol) {
+	// 클릭한 칸의 주위 9칸을 확인
+	for (int i = clickedCellRow - 1; i <= clickedCellRow + 1; i++) {
+		if (i < 0 || i >= row) {
+			continue;
+		}
+		for (int j = clickedCellCol - 1; j <= clickedCellCol + 1; j++) {
+			if (j < 0 || j >= col) {
+				continue;
+			}
+			switch (field[i][j].cellValue) {
+			case CellValue::Mine:
+				cells[i][j]->getBlock()->ChangeToFlagImage();
+				break;
+			default:
+				cells[i][j]->BreakBlock();
+				break;
+			}
+		}
+	}
 }
 
 BoardStatus Board::getBoardStatus() {

--- a/src/Board.h
+++ b/src/Board.h
@@ -49,33 +49,44 @@ private:
 	// 아이템 객체
 	std::shared_ptr<Item> item;
 
-	// 현재 사용중인 도구의 상태를 표시하기 위한 객체
-	ObjectPtr handObject;
-
-	// 남은 목숨
-	int life = LIFE_COUNT;
-
-	// 이벤트 핸들러
+	// 블럭 제거 이벤트 핸들러
 	std::shared_ptr<BlockBreakHandler> OnBlockBreak;
+
+	/*
+	* detector 아이템을 선택한 상태로 셀을 클릭할 경우를 처리할 함수
+	*/
+	void UseDetector(int clickedCellRow, int clickedCellCol);
 
 public:
 	Board(ScenePtr bg);
 
-	// 보드를 주어진 크기로 초기화하고 생성하는 함수
+	/*
+	* 보드를 주어진 크기로 초기화하고 생성하는 함수
+	*/ 
 	void RefreshBoard(int newRow, int newCol);
 
-	// 현재 보드를 초기화하는 함수
+	/*
+	* 현재 보드를 초기화하는 함수
+	*/ 
 	void Clear();
 
-	// 보드를 주어진 크기로 새로 생성하는 함수
+	/*
+	* 보드를 주어진 크기로 새로 생성하는 함수
+	*/ 
 	void GenerateNewBoard(int newRow, int newCol);
 
-	// 보드의 상태를 반환하는 함수
+	/*
+	* 보드의 상태를 반환하는 함수
+	*/ 
 	BoardStatus getBoardStatus();
 
-	// 보드의 가로 크기를 반환하는 함수
+	/*
+	* 보드의 가로 크기를 반환하는 함수
+	*/ 
 	int getRow();
 
-	// 보드의 세로 크기를 반환하는 함수
+	/*
+	* 보드의 세로 크기를 반환하는 함수
+	*/ 
 	int getCol();
 };

--- a/src/Cell.cpp
+++ b/src/Cell.cpp
@@ -29,6 +29,7 @@ _cell::_cell(ScenePtr bg, FieldData fieldData, int x, int y) {
 		itemObject->setScale(0.02f);
 		break;
 	default:
+		itemValue = ItemValue::None;
 		break;
 	}
 
@@ -88,6 +89,17 @@ void _cell::ChangeNumImage(FieldData fieldData) {
 void _cell::BreakBlock() {
 	if (this->block->HideBlock()) {
 		isOpened = true;
+	}
+	// ¾ÆÀÌÅÛÀ» È¹µæÇÏ¸é ¼¿ À§¿¡ ÀÖ´Â ¾ÆÀÌÅÛ ÀÌ¹ÌÁö¸¦ 
+	// ÀÏÁ¤ ½Ã°£ µÚ¿¡ ¾ø¾Ø´Ù. 
+	if (this->itemValue != ItemValue::None) {
+		showMessage("¾ÆÀÌÅÛÀ» È¹µæÇß½À´Ï´Ù!");
+		TimerPtr itemHideTimer = Timer::create(0.5f);
+		itemHideTimer->setOnTimerCallback([&](auto)->bool {
+			this->itemObject->hide();
+			return true;
+			});
+		itemHideTimer->start();
 	}
 }
 

--- a/src/Item.cpp
+++ b/src/Item.cpp
@@ -7,20 +7,18 @@ Item::Item(ScenePtr bg, int initLifeCount): background(bg), lifeCount(initLifeCo
 
 	// 현재 사용중인 아이템을 표시
 	currentItemIndicator = Object::create(ItemResource::INDICATOR, bg, 340, 0);
-	
-	ObjectPtr pickax = Object::create(ItemResource::PICKAX, background, 350, 10);
-	ObjectPtr flag = Object::create(ItemResource::FLAG, background, 450, 10);
-	ObjectPtr detector = Object::create(ItemResource::DETECTOR, background, 555, 10, false);
-	ObjectPtr spray = Object::create(ItemResource::SPRAY, background, 670, 10, false);
 
-	itemObject.push_back(pickax);
-	itemObject.push_back(flag);
-	itemObject.push_back(detector);
-	itemObject.push_back(spray);
+	// 아이템 바에서 보여줄 아이템 오브젝트 객체 생성
+	itemObject.resize(4);
+	itemObject[0] = Object::create(ItemResource::PICKAX, background, 350, 10);
+	itemObject[1] = Object::create(ItemResource::FLAG, background, 450, 10);
+	itemObject[2] = Object::create(ItemResource::DETECTOR, background, 555, 10, false);
+	itemObject[3] = Object::create(ItemResource::SPRAY, background, 670, 10, false);
 
+	// 아이템들의 개수 배열 초기화
 	itemCount.resize(4);
-	itemCount[0] = -1;
-	itemCount[1] = -1;
+	itemCount[0] = INFINITE;
+	itemCount[1] = INFINITE;
 	itemCount[2] = 0;
 	itemCount[3] = 0;
 
@@ -32,22 +30,22 @@ Item::Item(ScenePtr bg, int initLifeCount): background(bg), lifeCount(initLifeCo
 	// 아이템 객체에 대한 키보드 콜백
 	background->setOnKeyboardCallback([&](auto bg, auto KeyCode, auto pressed)->bool {
 		if (KeyCode == KeyCode::KEY_1 && pressed == true) {
-			ChangeHand(0);
+			ChangeHand(Hand::Pickax);
 		}
 		else if (KeyCode == KeyCode::KEY_2 && pressed == true) {
-			ChangeHand(1);
+			ChangeHand(Hand::Flag);
 		}
 		else if (KeyCode == KeyCode::KEY_3 && pressed == true) {
-			ChangeHand(2);
+			ChangeHand(Hand::Detector);
 		}
 		else if (KeyCode == KeyCode::KEY_4 && pressed == true) {
-			ChangeHand(3);
+			ChangeHand(Hand::Spray);
 		}
 		else if (KeyCode == KeyCode::KEY_5 && pressed == true) {
-			ChangeHand(4);
+			ChangeHandByIndex(4);
 		}
 		else if (KeyCode == KeyCode::KEY_6 && pressed == true) {
-			ChangeHand(5);
+			ChangeHandByIndex(5);
 		}
 		return true;
 		});
@@ -55,15 +53,16 @@ Item::Item(ScenePtr bg, int initLifeCount): background(bg), lifeCount(initLifeCo
 	// 아이템 객체들에 대한 마우스 콜백
 	for (int i = 0; i < itemObject.size(); i++) {
 		itemObject[i]->setOnMouseCallback([=](auto, auto, auto, auto)->bool {
-			ChangeHand(i);
+			ChangeHandByIndex(i);
 			return true;
 			});
 	}
 }
 
-Hand Item::getHand() {
-	return hand;
+Hand Item::getCurrentHand() {
+	return currentHand;
 }
+
 
 int Item::getItemIndex(Hand hand) {
 	switch (hand) {
@@ -80,24 +79,29 @@ int Item::getItemIndex(Hand hand) {
 	}
 }
 
-void Item::ChangeHand(int index) {
+void Item::ChangeHandByIndex(int index) {
 	currentItemIndicator->locate(background, 340 + (103 * index), 0);
 	switch (index) {
 	case 0:
-		hand = Hand::Pickax;
+		currentHand = Hand::Pickax;
 		break;
 	case 1:
-		hand = Hand::Flag;
+		currentHand = Hand::Flag;
 		break;
 	case 2:
-		hand = Hand::Detector;
+		currentHand = Hand::Detector;
 		break;
 	case 3:
-		hand = Hand::Spray;
+		currentHand = Hand::Spray;
 		break;
 	default:
 		break;
 	}
+}
+
+void Item::ChangeHand(Hand hand) {
+	int index = getItemIndex(hand);
+	ChangeHandByIndex(index);
 }
 
 int Item::getItemCount(Hand hand) {
@@ -105,35 +109,38 @@ int Item::getItemCount(Hand hand) {
 	return itemCount[index];
 }
 
-void Item::refreshCountImage(int index) {
-	itemCountOnject[index]->show();
-	switch (itemCount[index]) {
+void Item::refreshCountImage(int itemIndex) {
+	itemCountOnject[itemIndex]->show();
+	itemObject[itemIndex]->show();
+	switch (itemCount[itemIndex]) {
+	// 해당 아이템의 개수가 0이라면 아이템과 개수 숫자를 숨김
 	case 0:
-		itemCountOnject[index]->hide();
+		itemCountOnject[itemIndex]->hide();
+		itemObject[itemIndex]->hide();
 		break;
 	case 1:
-		itemCountOnject[index]->setImage(ItemResource::ONE);
+		itemCountOnject[itemIndex]->setImage(ItemResource::ONE);
 		break;
 	case 2:
-		itemCountOnject[index]->setImage(ItemResource::TWO);
+		itemCountOnject[itemIndex]->setImage(ItemResource::TWO);
 		break;
 	case 3:
-		itemCountOnject[index]->setImage(ItemResource::THREE);
+		itemCountOnject[itemIndex]->setImage(ItemResource::THREE);
 		break;
 	case 4:
-		itemCountOnject[index]->setImage(ItemResource::FOUR);
+		itemCountOnject[itemIndex]->setImage(ItemResource::FOUR);
 		break;
 	case 5:
-		itemCountOnject[index]->setImage(ItemResource::FIVE);
+		itemCountOnject[itemIndex]->setImage(ItemResource::FIVE);
 		break;
 	case 6:
-		itemCountOnject[index]->setImage(ItemResource::SIX);
+		itemCountOnject[itemIndex]->setImage(ItemResource::SIX);
 		break;
 	case 7:
-		itemCountOnject[index]->setImage(ItemResource::SEVEN);
+		itemCountOnject[itemIndex]->setImage(ItemResource::SEVEN);
 		break;
 	case 8:
-		itemCountOnject[index]->setImage(ItemResource::EIGHT);
+		itemCountOnject[itemIndex]->setImage(ItemResource::EIGHT);
 		break;
 	default:
 		break;
@@ -142,14 +149,15 @@ void Item::refreshCountImage(int index) {
 
 void Item::ReduceItem(Hand hand) {
 	int index = getItemIndex(hand);
-
-	if (itemCount[index] > 0) {
+	// 무한대를 개수로 갖는 아이템
+	if (itemCount[index] == INFINITE) {
+		return;
+	}
+	// 0개 이상의 개수를 갖는 아이템
+	else if (itemCount[index] > 0) {
 		itemCount[index]--;
 		refreshCountImage(index);
 	}
-
-	// 디버그용
-	std::cout << "Number of Item: " << itemCount[index] << std::endl;
 }
 
 void Item::refreshLifeCountImage() {
@@ -160,14 +168,14 @@ void Item::AddItem(ItemValue itemValue) {
 	int index;
 
 	switch (itemValue)	{
-	case AddLife:
+	case ItemValue::AddLife:
 		lifeCount++;
 		refreshLifeCountImage();
 		return;
-	case MineDetector:
+	case ItemValue::MineDetector:
 		index = getItemIndex(Hand::Detector);
 		break;
-	case AvoidCombat:
+	case ItemValue::AvoidCombat:
 		index = getItemIndex(Hand::Spray);
 		break;
 	default:

--- a/src/Item.h
+++ b/src/Item.h
@@ -2,10 +2,8 @@
 * Item.h
 *
 * 지뢰찾기 게임에서 아이템을 관리하는 클래스.
-* 아이템의 종류, 아이템의 개수, 현재 사용중인 아이템, 아이템바 객체 등은 이 클래스에서 관리한다.
+* 아이템의 종류, 아이템의 개수, 목숨의 개수, 현재 사용중인 아이템, 아이템바 객체 등은 이 클래스에서 관리한다.
 * 현재 사용중인 아이템이 무엇인지는 이 클래스로부터 다른 클래스들로 전달된다.
-* 아이템은 9칸을 강제로 열어주는 아이템, 1번의 전투를 회피시켜주는 아이템이 있다.
-* 아이템의 최대 개수는 3개로 한다.
 */
 
 #pragma once
@@ -16,8 +14,14 @@
 #include "MineField.h"
 #include <bangtal>
 
+// 무한개의 아이템 개수 정의
+constexpr auto INFINITE = -1;
+
 using namespace bangtal;
 
+/*
+* 아이템 창에서 선택가능한 항목들
+*/
 enum class Hand {
 	//곡괭이
 	Pickax,
@@ -38,7 +42,7 @@ private:
 	int lifeCount;
 
 	// 현재 핸드 상황
-	Hand hand = Hand::Pickax;
+	Hand currentHand = Hand::Pickax;
 
 	// 아이템바 방탈 오브젝트
 	ObjectPtr itemBar;
@@ -59,13 +63,14 @@ public:
 	Item(ScenePtr bg, int initLifeCount);
 
 	// 현재 핸드를 확인하는 함수
-	Hand getHand();
+	Hand getCurrentHand();
 
 	// Hand에 해당하는 아이템 index를 반환하는 함수
 	int getItemIndex(Hand hand);
 
-	// Hand를 바꾸는 함수 - KeyboardCallback에 따라 다른 index를 인자로 받는다.
-	void ChangeHand(int index);
+	// Hand를 바꾸는 함수들
+	void ChangeHandByIndex(int index);
+	void ChangeHand(Hand hand);
 
 	// 현재 아이템의 개수를 확인하는 함수
 	int getItemCount(Hand hand);

--- a/src/MineField.h
+++ b/src/MineField.h
@@ -18,7 +18,7 @@
 /*
 * 지뢰와 숫자, 탈출구를 정의하는 enum.
 */
-enum CellValue {
+enum class CellValue {
 	Escape,
 	Mine,
 	Empty,
@@ -27,7 +27,7 @@ enum CellValue {
 /*
 * 아이템을 정의하는 enum.
 */
-enum ItemValue {
+enum class ItemValue {
 	AddLife,
 	MineDetector,
 	AvoidCombat,
@@ -35,8 +35,8 @@ enum ItemValue {
 };
 
 constexpr auto ADDLIFE_COUNT = 1;
-constexpr auto MINE_DETECTOR_COUNT = 1;
-constexpr auto AVOID_COMBAT_COUNT = 1;
+constexpr auto MINE_DETECTOR_COUNT = 3;
+constexpr auto AVOID_COMBAT_COUNT = 2;
 
 /*
 * 한 cell에 담긴 정보를 전달할 때 사용할 클래스.


### PR DESCRIPTION
1. 함수와 변수의 이름을 조금 더 분명하게 수정하였습니다. (예: ChangeFlagImage -> ChangeToFlagImage, ChangeHand -> ChangeHandByIndex, hand -> currentHand)
2. 지뢰 탐지기의 작동을 구현하였습니다. 이제 지뢰 탐지기를 선택한 채로 블럭을 클릭하면 주위의 9칸을 살펴 그 중 지뢰가 아닌 칸은 열고 지뢰칸은 깃발을 세웁니다.
3. Cell 객체의 itemValue가 초기화되지 않아 모든 cell이 ItemValue::AddLife 값을 가졌던 문제를 수정했습니다. 이제 아이템을 갖지 않는 모든 cell은 정상적으로 ItemValue::None을 갖습니다. 
4. 블럭을 열고 해당 셀에 있는 아이템을 보여주고 획득한 뒤, 일정 시간이 지나면 이를 안 보이도록 구현하였습니다. 이제 획득한 아이템이 계속 cell에 남아 숫자를 가리지 않습니다. 