### PR TITLE
목숨+1 아이템의 작동과 전투 패배 시 목숨을 차감하는 것, 남은 목숨이 없을 때 게임 오버 되는 것을 구현

### DIFF
--- a/src/BlockBreakHandler.h
+++ b/src/BlockBreakHandler.h
@@ -22,7 +22,7 @@
 #include "Combats/RockPaperScissor.h"
 #include "Combats/ShootTheMonster.h"
 
-#define DEBUG
+//#define DEBUG
 
 using namespace bangtal;
 
@@ -48,8 +48,6 @@ private:
 	// 현재 보드의 크기
 	int& row, col;
 
-	// 현재 보드의 상태
-	BoardStatus status = BoardStatus::Playing;
 
 	// 현재 보드의 배경
 	ScenePtr boardBackground;
@@ -66,6 +64,9 @@ private:
 	// 모든 셀의 2차원 벡터를 참조
 	std::vector<std::vector<CellPtr>>& cells;
 
+	// 현재 보드의 상태 참조
+	BoardStatus& status;
+
 	// 새로 열린 cell이 있는지 체크할 타이머
 	TimerPtr refreshTimer;
 
@@ -74,7 +75,7 @@ private:
 
 public:
 	BlockBreakHandler(int& newRow, int& newCol, MineField& newField, std::vector<std::vector<CellPtr>>& newCells, 
-		std::shared_ptr<Item> item, ScenePtr boardBackground);
+		std::shared_ptr<Item> item, ScenePtr boardBackground, BoardStatus& status);
 	~BlockBreakHandler();
 
 
@@ -95,6 +96,11 @@ public:
 	void EnterRandomCombat(int curRow, int curCol);
 
 	/*
+	* 전투에서 패배할 경우를 처리하는 함수
+	*/
+	void looseCombat();
+
+	/*
 	* 빈 칸의 경계에 있는 cell들을 열어 확장하는 함수
 	*/
 	void ExpandBorder(int curRow, int curCol);
@@ -109,11 +115,6 @@ public:
 	* Timer를 초기화하기 위해 필요함.
 	*/
 	void StopCheckNewCellOpened();
-
-	/*
-	* 보드의 상태를 반환하는 함수
-	*/
-	BoardStatus getStatus();
 
 	/*
 	* 보드의 상태를 갱신하는 함수

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -17,11 +17,11 @@ Board::Board(ScenePtr bg) {
 
 void Board::RefreshBoard(int newRow, int newCol) {
 	// 반드시 클리어 시에만 이 함수를 호출할 것!
-	if (OnBlockBreak->getStatus() == BoardStatus::Playing) {
+	if (status == BoardStatus::Playing) {
 		std::cout << "클리어되지 못한 보드의 초기화가 발생했습니다." << std::endl;
 		exit(1);
 	}
-	else if (OnBlockBreak->getStatus() == BoardStatus::GameOver) {
+	else if (status == BoardStatus::GameOver) {
 		std::cout << "게임오버된 보드의 초기화가 발생했습니다." << std::endl;
 		exit(1);
 	}
@@ -56,7 +56,7 @@ void Board::GenerateNewBoard(int newRow, int newCol) {
 	col = newCol;
 
 	// 보드가 새로 생성될 때마다 새로운 이벤트 핸들러 객체 생성
-	OnBlockBreak = std::make_shared<BlockBreakHandler>(row, col, field, cells, item, background);
+	OnBlockBreak = std::make_shared<BlockBreakHandler>(row, col, field, cells, item, background, status);
 
 	// field 재생성
 	field.Resize(row, col);
@@ -137,7 +137,7 @@ void Board::UseDetector(int clickedCellRow, int clickedCellCol) {
 }
 
 BoardStatus Board::getBoardStatus() {
-	return OnBlockBreak->getStatus();
+	return status;
 }
 
 int Board::getRow() {
@@ -146,5 +146,9 @@ int Board::getRow() {
 
 int Board::getCol() {
 	return col;
+}
+
+void Board::setBoardStatus(BoardStatus status) {
+	this->status = status;
 }
 

--- a/src/Board.h
+++ b/src/Board.h
@@ -52,6 +52,9 @@ private:
 	// 블럭 제거 이벤트 핸들러
 	std::shared_ptr<BlockBreakHandler> OnBlockBreak;
 
+	// 현재 보드의 상태
+	BoardStatus status = BoardStatus::Playing;
+
 	/*
 	* detector 아이템을 선택한 상태로 셀을 클릭할 경우를 처리할 함수
 	*/
@@ -89,4 +92,9 @@ public:
 	* 보드의 세로 크기를 반환하는 함수
 	*/ 
 	int getCol();
+
+	/*
+	* 보드의 상태를 설정하는 함수
+	*/
+	void setBoardStatus(BoardStatus status);
 };

--- a/src/Combats/DiceMatching.cpp
+++ b/src/Combats/DiceMatching.cpp
@@ -1,6 +1,7 @@
 #include "DiceMatching.h"
 
-DiceMatching::DiceMatching(ScenePtr previousScene){
+DiceMatching::DiceMatching(ScenePtr previousScene, BlockBreakHandler& blockBreakHandler, std::function<void(BlockBreakHandler&)> gameOverFunc)
+	: blockBreakHandler(blockBreakHandler), gameOverFunc(gameOverFunc) {
 	this->previousScene = previousScene;
 	// 난수 생성 엔진 초기화
 	std::random_device rd;
@@ -152,12 +153,7 @@ void DiceMatching::CompareChoice() {
 		opportunity.pop_back();
 		// 남은 기회가 없다면 게임 오버
 		if (opportunity.size() == 0) {
-			showMessage("게임 오버!");
-			/*
-			*
-			* 게임오버시 타이틀로 돌아갈 것!
-			*
-			*/
+			gameOverFunc(blockBreakHandler);
 		}
 		else {
 			showMessage("몬스터가 이겼습니다...");

--- a/src/Combats/DiceMatching.h
+++ b/src/Combats/DiceMatching.h
@@ -6,6 +6,8 @@
 #include <bangtal>
 using namespace bangtal;
 
+class BlockBreakHandler;
+
 namespace DiceMatchingConfig {
 
 	// 몬스터의 숫자
@@ -58,8 +60,12 @@ private:
 	// 플레이어의 선택
 	int playerChoice;
 
+	// 게임 오버시 실행할 BlockBreakHandler의 멤버 함수 객체
+	std::function<void(BlockBreakHandler&)> gameOverFunc;
+	BlockBreakHandler& blockBreakHandler;
+
 public:
-	DiceMatching(ScenePtr previousScene);
+	DiceMatching(ScenePtr previousScene, BlockBreakHandler& blockBreakHandler, std::function<void(BlockBreakHandler&)> gameOverFunc);
 
 	/*
 	* 전투에 진입하는 함수

--- a/src/Combats/DiceRolling.cpp
+++ b/src/Combats/DiceRolling.cpp
@@ -6,7 +6,8 @@ std::string RDBattleBackground[] = {
 	CombatResource::BACKGROUND3
 };
 
-DiceRolling::DiceRolling(ScenePtr previousScene) {
+DiceRolling::DiceRolling(ScenePtr previousScene, BlockBreakHandler& blockBreakHandler, std::function<void(BlockBreakHandler&)> gameOverFunc)
+	: blockBreakHandler(blockBreakHandler), gameOverFunc(gameOverFunc) {
 	this->previousScene = previousScene;
 
 	// 난수 생성 엔진 초기화
@@ -144,12 +145,7 @@ void DiceRolling::CompareDice() {
 		opportunity.pop_back();
 		// 남은 기회가 없다면 게임 오버
 		if (opportunity.size() == 0) {
-			showMessage("게임 오버!");
-			/*
-			*
-			* 게임오버시 타이틀로 돌아갈 것!
-			*
-			*/
+			gameOverFunc(blockBreakHandler);
 		}
 		else {
 			showMessage("몬스터가 이겼습니다...");

--- a/src/Combats/DiceRolling.h
+++ b/src/Combats/DiceRolling.h
@@ -22,6 +22,8 @@ namespace DiceRollingConfig {
 	constexpr auto VISIBLE_TIME = 1;
 }
 
+class BlockBreakHandler;
+
 class DiceRolling : public Combat {
 private:
 
@@ -54,8 +56,12 @@ private:
 	// 클릭하면 주사위를 굴리는 버튼
 	ObjectPtr rollingButton;
 
+	// 게임 오버시 실행할 BlockBreakHandler의 멤버 함수 객체
+	std::function<void(BlockBreakHandler&)> gameOverFunc;
+	BlockBreakHandler& blockBreakHandler;
+
 public:
-	DiceRolling(ScenePtr previousScene);
+	DiceRolling(ScenePtr previousScene, BlockBreakHandler& blockBreakHandler, std::function<void(BlockBreakHandler&)> gameOverFunc);
 
 	/*
 	* 전투에 진입하는 함수

--- a/src/Combats/OddOrEven.cpp
+++ b/src/Combats/OddOrEven.cpp
@@ -1,6 +1,7 @@
 #include "OddOrEven.h"
 
-OddOrEven::OddOrEven(ScenePtr previousScene) {
+OddOrEven::OddOrEven(ScenePtr previousScene, BlockBreakHandler& blockBreakHandler, std::function<void(BlockBreakHandler&)> gameOverFunc)
+	: blockBreakHandler(blockBreakHandler), gameOverFunc(gameOverFunc) {
 	this->previousScene = previousScene;
 	// 난수 생성 엔진 초기화
 	std::random_device rd;
@@ -139,12 +140,7 @@ void OddOrEven::CompareChoice() {
 		opportunity.pop_back();
 		// 남은 기회가 없다면 게임 오버
 		if (opportunity.size() == 0) {
-			showMessage("게임 오버!");
-			/*
-			*
-			* 게임오버시 타이틀로 돌아갈 것!
-			*
-			*/
+			gameOverFunc(blockBreakHandler);
 		}
 		else {
 			showMessage("몬스터가 이겼습니다...");

--- a/src/Combats/OddOrEven.h
+++ b/src/Combats/OddOrEven.h
@@ -13,6 +13,8 @@
 #include <bangtal>
 using namespace bangtal;
 
+class BlockBreakHandler;
+
 enum PlayerChoice {
 	Odd,
 	Even,
@@ -65,8 +67,12 @@ private:
 	// 플레이어의 선택
 	PlayerChoice playerChoice;
 
+	// 게임 오버시 실행할 BlockBreakHandler의 멤버 함수 객체
+	std::function<void(BlockBreakHandler&)> gameOverFunc;
+	BlockBreakHandler& blockBreakHandler;
+
 public:
-	OddOrEven(ScenePtr previousScene);
+	OddOrEven(ScenePtr previousScene, BlockBreakHandler& blockBreakHandler, std::function<void(BlockBreakHandler&)> gameOverFunc);
 
 	/*
 	* 전투에 진입하는 함수

--- a/src/Combats/RockPaperScissor.cpp
+++ b/src/Combats/RockPaperScissor.cpp
@@ -6,7 +6,8 @@ std::string RPSBattleBackground[] = {
 	CombatResource::BACKGROUND3
 };
 
-RockPaperScissor::RockPaperScissor(ScenePtr previousScene) {
+RockPaperScissor::RockPaperScissor(ScenePtr previousScene, BlockBreakHandler& blockBreakHandler, std::function<void(BlockBreakHandler&)> gameOverFunc)
+	: blockBreakHandler(blockBreakHandler), gameOverFunc(gameOverFunc) {
 
 	this->previousScene = previousScene;
 
@@ -131,12 +132,7 @@ void RockPaperScissor::CompareChoices() {
 		opportunity.pop_back();
 		// 남은 기회가 없다면 게임 오버
 		if (opportunity.size() == 0) {
-			showMessage("게임 오버!");
-			/*
-			* 
-			* 게임오버시 타이틀로 돌아갈 것!
-			* 
-			*/
+			gameOverFunc(blockBreakHandler);
 		}
 		else {
 			showMessage("몬스터가 이겼습니다...");

--- a/src/Combats/RockPaperScissor.h
+++ b/src/Combats/RockPaperScissor.h
@@ -32,6 +32,8 @@ enum HandType {
 	NoChoice,
 };
 
+class BlockBreakHandler;
+
 class RockPaperScissor : public Combat {
 private:
 
@@ -59,8 +61,12 @@ private:
 	// 컴퓨터의 선택
 	HandType computerChoice = HandType::NoChoice;;
 
+	// 게임 오버시 실행할 BlockBreakHandler의 멤버 함수 객체
+	std::function<void(BlockBreakHandler&)> gameOverFunc;
+	BlockBreakHandler& blockBreakHandler;
+
 public:
-	RockPaperScissor(ScenePtr previousScene);
+	RockPaperScissor(ScenePtr previousScene, BlockBreakHandler& blockBreakHandler, std::function<void(BlockBreakHandler&)> gameOverFunc);
 
 	/*
 	* 전투에 진입하는 함수

--- a/src/Combats/ShootTheMonster.cpp
+++ b/src/Combats/ShootTheMonster.cpp
@@ -1,6 +1,7 @@
 #include "ShootTheMonster.h"
 
-ShootTheMonster::ShootTheMonster(ScenePtr previousScene) {
+ShootTheMonster::ShootTheMonster(ScenePtr previousScene, BlockBreakHandler& blockBreakHandler, std::function<void(BlockBreakHandler&)> gameOverFunc)
+	: blockBreakHandler(blockBreakHandler), gameOverFunc(gameOverFunc) {
 	this->previousScene = previousScene;
 	// 난수 생성 엔진 초기화
 	std::random_device rd;
@@ -143,23 +144,13 @@ void ShootTheMonster::CompareDirection(Direction playerDir, Direction monsterDir
 		}
 	}
 	else if (opportunity.size() < monsterRemainCount) {
-		showMessage("총알이 부족합니다.\n게임 오버!");
 		monsterShowTimer->stop();
-		/*
-		*
-		* 게임오버시 타이틀로 돌아갈 것!
-		*
-		*/
+		gameOverFunc(blockBreakHandler);
 	}
 	else {
 		if (opportunity.size() == 0) {
-			showMessage("게임 오버!");
 			monsterShowTimer->stop();
-			/*
-			*
-			* 게임오버시 타이틀로 돌아갈 것!
-			*
-			*/
+			gameOverFunc(blockBreakHandler);
 		}
 		else {
 			showMessage("놓쳤습니다!");

--- a/src/Combats/ShootTheMonster.h
+++ b/src/Combats/ShootTheMonster.h
@@ -34,6 +34,8 @@ namespace ShootTheMonsterConfig {
 	constexpr auto VISIBLE_TIME = 0.5;
 }
 
+class BlockBreakHandler;
+
 class ShootTheMonster : public Combat {
 
 private:
@@ -69,9 +71,12 @@ private:
 	// 플레이어가 쏜 방향
 	Direction playerShootDir;
 
+	// 게임 오버시 실행할 BlockBreakHandler의 멤버 함수 객체
+	std::function<void(BlockBreakHandler&)> gameOverFunc;
+	BlockBreakHandler& blockBreakHandler;
 
 public:
-	ShootTheMonster(ScenePtr previousScene);
+	ShootTheMonster(ScenePtr previousScene, BlockBreakHandler& blockBreakHandler, std::function<void(BlockBreakHandler&)> gameOverFunc);
 
 	/*
 	* 전투에 진입하는 함수

--- a/src/Item.cpp
+++ b/src/Item.cpp
@@ -1,6 +1,13 @@
 #include "Item.h"
 
-Item::Item(ScenePtr bg, int initLifeCount): background(bg), lifeCount(initLifeCount) {
+Item::Item(ScenePtr bg, int initLifeCount): background(bg) {
+
+	// 목숨 이미지 생성
+	lifeObject.resize(initLifeCount);
+	for (int i = 0; i < lifeObject.size(); i++) {
+		lifeObject[i] = Object::create(ItemResource::LIFE, background, 1200 - i * 65, 650);
+		lifeObject[i]->setScale(0.05f);
+	}
 
 	//아이템바 위치 생성
 	itemBar = Object::create(ItemResource::ITEM_BAR, background, 340, 0);
@@ -21,7 +28,6 @@ Item::Item(ScenePtr bg, int initLifeCount): background(bg), lifeCount(initLifeCo
 	itemCount[1] = INFINITE;
 	itemCount[2] = 0;
 	itemCount[3] = 0;
-
 	itemCountOnject.resize(4);
 	for (int i = 0; i < itemCount.size(); i++) {
 		itemCountOnject[i] = Object::create(ItemResource::EMPTY, background, 400 + (103 * i), 7, false);
@@ -160,17 +166,12 @@ void Item::ReduceItem(Hand hand) {
 	}
 }
 
-void Item::refreshLifeCountImage() {
-
-}
-
 void Item::AddItem(ItemValue itemValue) {
 	int index;
 
 	switch (itemValue)	{
 	case ItemValue::AddLife:
-		lifeCount++;
-		refreshLifeCountImage();
+		AddLifeCount();
 		return;
 	case ItemValue::MineDetector:
 		index = getItemIndex(Hand::Detector);
@@ -196,4 +197,22 @@ void Item::AddItem(ItemValue itemValue) {
 	itemCount[index]++;
 
 	refreshCountImage(index);
+}
+
+void Item::ReduceLifeCount() {
+	if (lifeObject.size() > 0) {
+		lifeObject.back()->hide();
+		lifeObject.pop_back();
+	}
+}
+
+void Item::AddLifeCount() {
+	if (lifeObject.size() < 19) {
+		lifeObject.push_back(Object::create(ItemResource::LIFE, background, 1200 - lifeObject.size() * 65, 650));
+		lifeObject.back()->setScale(0.05f);
+	}
+}
+
+int Item::getLifeCount() {
+	return lifeObject.size();
 }

--- a/src/Item.h
+++ b/src/Item.h
@@ -16,6 +16,8 @@
 
 // 무한개의 아이템 개수 정의
 constexpr auto INFINITE = -1;
+// 목숨의 가능한 최대의 개수 정의
+constexpr auto MAX_LIFE_COUNT = 19;
 
 using namespace bangtal;
 
@@ -38,9 +40,6 @@ private:
 	// 현재 플레이되고 있는 배경
 	ScenePtr background;
 
-	// 남은 목숨 개수
-	int lifeCount;
-
 	// 현재 핸드 상황
 	Hand currentHand = Hand::Pickax;
 
@@ -59,31 +58,65 @@ private:
 	// 현재 사용중인 아이템을 표시해줄 테두리 방탈오브젝트
 	ObjectPtr currentItemIndicator;
 
+	// 목숨 이미지 오브젝트 벡터
+	// 이 벡터의 크기가 곧 목숨의 개수이다. 
+	std::vector<ObjectPtr> lifeObject;
+
+	// 스프레이 사용 후 인디케이터
+	ObjectPtr sprayUsedIndicator;
+	bool isSprayUsed;
+
+	/*
+	* 해당 아이템의 itemCount 값에 따라 Item개수 이미지를 변경하는 함수
+	*/
+	void refreshCountImage(int itemIndex);
+
+	/*
+	* Hand에 해당하는 아이템 index를 반환하는 함수
+	*/
+	int getItemIndex(Hand hand);
+
 public:
 	Item(ScenePtr bg, int initLifeCount);
 
-	// 현재 핸드를 확인하는 함수
+	/*
+	* 현재 핸드를 확인하는 함수
+	*/ 
 	Hand getCurrentHand();
 
-	// Hand에 해당하는 아이템 index를 반환하는 함수
-	int getItemIndex(Hand hand);
-
-	// Hand를 바꾸는 함수들
+	/*
+	* Hand를 바꾸는 함수들
+	*/ 
 	void ChangeHandByIndex(int index);
 	void ChangeHand(Hand hand);
 
-	// 현재 아이템의 개수를 확인하는 함수
+	/*
+	* 현재 아이템의 개수를 확인하는 함수
+	*/ 
 	int getItemCount(Hand hand);
 
-	// 해당 아이템의 itemCount 값에 따라 Item개수 이미지를 변경하는 함수
-	void refreshCountImage(int itemIndex);
-
-	// 목숨 이미지를 새로고치는 함수
-	void refreshLifeCountImage();
-
-	// 아이템의 개수를 줄이는 함수
+	/*
+	* 아이템의 개수를 줄이는 함수
+	*/ 
 	void ReduceItem(Hand hand);
 
-	// 아이템의 개수를 늘리는 함수
+	/*
+	* 아이템의 개수를 늘리는 함수
+	*/ 
 	void AddItem(ItemValue itemValue);
+
+	/*
+	* 목숨의 개수를 하나 줄이는 함수
+	*/
+	void ReduceLifeCount();
+
+	/*
+	* 목숨을 하나 추가하는 함수
+	*/
+	void AddLifeCount();
+
+	/*
+	* 목숨 개수를 반환하는 함수
+	*/
+	int getLifeCount();
 };

--- a/src/Stage.cpp
+++ b/src/Stage.cpp
@@ -32,6 +32,7 @@ void Stage::EventHandler() {
 		// GameOver -> 보드 초기화?
 		if (board->getBoardStatus() == BoardStatus::GameOver) {
 			// ** 디버그용 ** 게임 종료
+			std::cout << "게임 오버!";
 			endGame();
 		}
 		boardStatusChecker->set(REFRESH_TIME);
@@ -40,9 +41,6 @@ void Stage::EventHandler() {
 		});
 
 	boardStatusChecker->start();
-
-	// 디버그용 타이머 생성 메세지
-	std::cout << ". . . Now Board Status Checker is working . . ." << std::endl;
 }
 
 void Stage::NextStage() {

--- a/src/resource.h
+++ b/src/resource.h
@@ -34,6 +34,7 @@ namespace BlockResource {
 }
 
 namespace ItemResource {
+	constexpr auto LIFE = "image/Item_Heart.png";
 	constexpr auto INDICATOR = "image/ItemBox_using.png";
 	constexpr auto ITEM_BAR = "image/ItemBox.png";
 	constexpr auto PICKAX = "image/Item_Pickax.png";


### PR DESCRIPTION
1. Item 클래스에서 목숨을 화면에 표시하고 관리할 수 있도록 하였습니다. \
2. 목숨+1 아이템을 획득할 때 목숨이 증가하도록 구현하였습니다. 
3. 핸들러와 아이템 클래스 객체를 연결해 전투에서 패배하면 목숨이 줄어들도록 하였습니다. 
4. 목숨이 0개가 되면 stage의 타이머가 게임 오버 이벤트를 일으킬 수 있도록 연결하였습니다. 