### PR TITLE
spray 아이템 구현, 전투 상황에서 입력 제한, 리펙토링

### DIFF
--- a/src/BlockBreakHandler.cpp
+++ b/src/BlockBreakHandler.cpp
@@ -54,7 +54,14 @@ void BlockBreakHandler::CheckIsItemExist(int curRow, int curCol) {
 }
 
 void BlockBreakHandler::EnterRandomCombat(int curRow, int curCol) {
+	// 빈칸이면
 	if (field[curRow][curCol].cellValue != CellValue::Mine) {
+		return;
+	}
+	// 스프레이를 사용중이면
+	else if (item->getIsSprayUsed()) {
+		item->UseSpray();
+		showMessage("스프레이의 효과로 몬스터를 피했습니다!");
 		return;
 	}
 	std::random_device rd;

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -74,28 +74,20 @@ void Board::GenerateNewBoard(int newRow, int newCol) {
 			CellPtr cell = Cell::Create(background, field[i][j], x, y);
 			
 
-			// Item의 정보를 셀의 콜백 함수가 참조해야 함
+			// 현재 hand에 따라서 다른 작동을 한다. 
 			cell->getBlock()->setClickCallback([=](auto object, int x, int y, auto action)->bool {
-				switch (item->getCurrentHand())
-				{
+				switch (item->getCurrentHand()) {
+				case Hand::Pickax:
+					cell->BreakBlock();
+					break;
+				case Hand::Flag:
+					cell->getBlock()->SwapBlockImage();
+					break;
+				case Hand::Detector:
+					item->UseDetector(i, j, cells, field);
+					break;
 				default:
 					break;
-				}
-				// 핸드가 곡괭이일 경우
-				if (item->getCurrentHand() == Hand::Pickax) {
-					cell->BreakBlock();
-				}
-				// 핸드가 깃발일경우
-				else if (item->getCurrentHand() == Hand::Flag) {
-					cell->getBlock()->SwapBlockImage();
-				}
-				// 현재 선택한 아이템이 detector일 경우
-				else if (item->getCurrentHand() == Hand::Detector) {
-					if (item->getItemCount(Hand::Detector) > 0) {
-						UseDetector(i, j);
-						item->ReduceItem(Hand::Detector);
-						item->ChangeHand(Hand::Pickax);
-					}
 				}
 				
 				return true;
@@ -112,28 +104,6 @@ void Board::GenerateNewBoard(int newRow, int newCol) {
 
 	// 새 보드 생성이 완료되면 이벤트 핸들러의 루프 시작
 	OnBlockBreak->CheckNewCellOpened();
-}
-
-void Board::UseDetector(int clickedCellRow, int clickedCellCol) {
-	// 클릭한 칸의 주위 9칸을 확인
-	for (int i = clickedCellRow - 1; i <= clickedCellRow + 1; i++) {
-		if (i < 0 || i >= row) {
-			continue;
-		}
-		for (int j = clickedCellCol - 1; j <= clickedCellCol + 1; j++) {
-			if (j < 0 || j >= col) {
-				continue;
-			}
-			switch (field[i][j].cellValue) {
-			case CellValue::Mine:
-				cells[i][j]->getBlock()->ChangeToFlagImage();
-				break;
-			default:
-				cells[i][j]->BreakBlock();
-				break;
-			}
-		}
-	}
 }
 
 BoardStatus Board::getBoardStatus() {

--- a/src/Board.h
+++ b/src/Board.h
@@ -55,10 +55,6 @@ private:
 	// 현재 보드의 상태
 	BoardStatus status = BoardStatus::Playing;
 
-	/*
-	* detector 아이템을 선택한 상태로 셀을 클릭할 경우를 처리할 함수
-	*/
-	void UseDetector(int clickedCellRow, int clickedCellCol);
 
 public:
 	Board(ScenePtr bg);

--- a/src/Combat.h
+++ b/src/Combat.h
@@ -11,6 +11,7 @@
 #pragma once
 #include "resource.h"
 
+//#define COMBAT_DEBUG
 
 class Combat {
 public:

--- a/src/Combats/DiceMatching.cpp
+++ b/src/Combats/DiceMatching.cpp
@@ -1,7 +1,7 @@
 #include "DiceMatching.h"
 
 DiceMatching::DiceMatching(ScenePtr previousScene, BlockBreakHandler& blockBreakHandler, std::function<void(BlockBreakHandler&)> gameOverFunc)
-	: blockBreakHandler(blockBreakHandler), gameOverFunc(gameOverFunc) {
+	: inputLock(false), blockBreakHandler(blockBreakHandler), gameOverFunc(gameOverFunc) {
 	this->previousScene = previousScene;
 	// 난수 생성 엔진 초기화
 	std::random_device rd;
@@ -54,6 +54,8 @@ void DiceMatching::EnterBattle(){
 	resultDelayTimer = Timer::create(DiceMatchingConfig::VISIBLE_TIME);
 	resultDelayTimer->setOnTimerCallback([&](auto)->bool {
 		diceAnimation->start();
+		// 결과가 나오면 입력 잠금을 푼다. 
+		inputLock = false;
 		return true;
 		});
 
@@ -126,11 +128,18 @@ void DiceMatching::ChangeDiceNumRandomly() {
 }
 
 bool DiceMatching::InputPlayerChoice(int num) {
+#ifndef COMBAT_DEBUG
+	// 입력 불가능 상태라면 입력받지 않는다. 
+	if (inputLock == true) {
+		return true;
+	}
+#endif // !COMBAT_DEBUG
 	playerChoice = num;
 	diceAnimation->stop();
 	CompareChoice();
 	resultDelayTimer->set(DiceMatchingConfig::VISIBLE_TIME);
 	resultDelayTimer->start();
+	inputLock = true;
 	return true;
 }
 

--- a/src/Combats/DiceMatching.h
+++ b/src/Combats/DiceMatching.h
@@ -60,6 +60,9 @@ private:
 	// 플레이어의 선택
 	int playerChoice;
 
+	// 결과 표시 중에 플레이어의 입력을 막을 lock
+	bool inputLock;
+
 	// 게임 오버시 실행할 BlockBreakHandler의 멤버 함수 객체
 	std::function<void(BlockBreakHandler&)> gameOverFunc;
 	BlockBreakHandler& blockBreakHandler;

--- a/src/Combats/DiceRolling.h
+++ b/src/Combats/DiceRolling.h
@@ -39,6 +39,9 @@ private:
 
 	// 기회 오브젝트 배열
 	std::vector<ObjectPtr> opportunity;
+
+	// 결과 표시 중에 플레이어의 입력을 막을 lock
+	bool inputLock;
 	
 	// 플레이어와 컴퓨터의 주사위
 	ObjectPtr computerDice;
@@ -54,7 +57,7 @@ private:
 	TimerPtr resultDelayTimer;
 
 	// 클릭하면 주사위를 굴리는 버튼
-	ObjectPtr rollingButton;
+	ObjectPtr stopButton;
 
 	// 게임 오버시 실행할 BlockBreakHandler의 멤버 함수 객체
 	std::function<void(BlockBreakHandler&)> gameOverFunc;

--- a/src/Combats/OddOrEven.cpp
+++ b/src/Combats/OddOrEven.cpp
@@ -63,40 +63,31 @@ void OddOrEven::EnterBattle() {
 	EvenButton = Object::create(CombatResource::OddOrEven::EvenButton, background, 380, -100);
 
 	OddButton->setOnMouseCallback([&](auto, auto, auto, auto)->bool {
-#ifndef COMBAT_DEBUG
-		// 입력 불가능 상태라면 입력받지 않는다. 
-		if (inputLock == true) {
-			return true;
-		}
-#endif // !COMBAT_DEBUG
-		playerChoice = PlayerChoice::Odd;
-		diceAnimation->stop();
-		CompareChoice();
-		resultDelayTimer->set(OddOrEvenConfig::VISIBLE_TIME);
-		resultDelayTimer->start();
-		// 결과가 나오는 동안 입력을 잠근다. 
-		inputLock = true;
-		return true;
+		return InputChoice(PlayerChoice::Odd);
 		});
 
 	EvenButton->setOnMouseCallback([&](auto, auto, auto, auto)->bool {
-#ifndef COMBAT_DEBUG
-		// 입력 불가능 상태라면 입력받지 않는다. 
-		if (inputLock == true) {
-			return true;
-		}
-#endif // !COMBAT_DEBUG
-		playerChoice = PlayerChoice::Even;
-		diceAnimation->stop();
-		CompareChoice();
-		resultDelayTimer->set(OddOrEvenConfig::VISIBLE_TIME);
-		resultDelayTimer->start();
-		// 결과가 나오는 동안 입력을 잠근다. 
-		inputLock = true;
-		return true;
+		return InputChoice(PlayerChoice::Even);
 		});
 
 	diceAnimation->start();
+}
+
+bool OddOrEven::InputChoice(PlayerChoice choice) {
+#ifndef COMBAT_DEBUG
+	// 입력 불가능 상태라면 입력받지 않는다. 
+	if (inputLock == true) {
+		return true;
+	}
+#endif // !COMBAT_DEBUG
+	playerChoice = choice;
+	diceAnimation->stop();
+	CompareChoice();
+	resultDelayTimer->set(OddOrEvenConfig::VISIBLE_TIME);
+	resultDelayTimer->start();
+	// 결과가 나오는 동안 입력을 잠근다. 
+	inputLock = true;
+	return true;
 }
 
 void OddOrEven::ChangeDiceNumRandomly(int* value, ObjectPtr object) {

--- a/src/Combats/OddOrEven.cpp
+++ b/src/Combats/OddOrEven.cpp
@@ -1,7 +1,7 @@
 #include "OddOrEven.h"
 
 OddOrEven::OddOrEven(ScenePtr previousScene, BlockBreakHandler& blockBreakHandler, std::function<void(BlockBreakHandler&)> gameOverFunc)
-	: blockBreakHandler(blockBreakHandler), gameOverFunc(gameOverFunc) {
+	: inputLock(false), blockBreakHandler(blockBreakHandler), gameOverFunc(gameOverFunc) {
 	this->previousScene = previousScene;
 	// 난수 생성 엔진 초기화
 	std::random_device rd;
@@ -54,6 +54,8 @@ void OddOrEven::EnterBattle() {
 	resultDelayTimer = Timer::create(OddOrEvenConfig::VISIBLE_TIME);
 	resultDelayTimer->setOnTimerCallback([&](auto)->bool {
 		diceAnimation->start();
+		// 결과가 나오면 입력 잠금을 푼다. 
+		inputLock = false;
 		return true;
 		});
 
@@ -61,20 +63,36 @@ void OddOrEven::EnterBattle() {
 	EvenButton = Object::create(CombatResource::OddOrEven::EvenButton, background, 380, -100);
 
 	OddButton->setOnMouseCallback([&](auto, auto, auto, auto)->bool {
+#ifndef COMBAT_DEBUG
+		// 입력 불가능 상태라면 입력받지 않는다. 
+		if (inputLock == true) {
+			return true;
+		}
+#endif // !COMBAT_DEBUG
 		playerChoice = PlayerChoice::Odd;
 		diceAnimation->stop();
 		CompareChoice();
 		resultDelayTimer->set(OddOrEvenConfig::VISIBLE_TIME);
 		resultDelayTimer->start();
+		// 결과가 나오는 동안 입력을 잠근다. 
+		inputLock = true;
 		return true;
 		});
 
 	EvenButton->setOnMouseCallback([&](auto, auto, auto, auto)->bool {
+#ifndef COMBAT_DEBUG
+		// 입력 불가능 상태라면 입력받지 않는다. 
+		if (inputLock == true) {
+			return true;
+		}
+#endif // !COMBAT_DEBUG
 		playerChoice = PlayerChoice::Even;
 		diceAnimation->stop();
 		CompareChoice();
 		resultDelayTimer->set(OddOrEvenConfig::VISIBLE_TIME);
 		resultDelayTimer->start();
+		// 결과가 나오는 동안 입력을 잠근다. 
+		inputLock = true;
 		return true;
 		});
 

--- a/src/Combats/OddOrEven.h
+++ b/src/Combats/OddOrEven.h
@@ -67,6 +67,9 @@ private:
 	// 플레이어의 선택
 	PlayerChoice playerChoice;
 
+	// 결과 표시 중에 플레이어의 입력을 막을 lock
+	bool inputLock;
+
 	// 게임 오버시 실행할 BlockBreakHandler의 멤버 함수 객체
 	std::function<void(BlockBreakHandler&)> gameOverFunc;
 	BlockBreakHandler& blockBreakHandler;

--- a/src/Combats/OddOrEven.h
+++ b/src/Combats/OddOrEven.h
@@ -15,7 +15,7 @@ using namespace bangtal;
 
 class BlockBreakHandler;
 
-enum PlayerChoice {
+enum class PlayerChoice {
 	Odd,
 	Even,
 };
@@ -73,6 +73,11 @@ private:
 	// 게임 오버시 실행할 BlockBreakHandler의 멤버 함수 객체
 	std::function<void(BlockBreakHandler&)> gameOverFunc;
 	BlockBreakHandler& blockBreakHandler;
+
+	/*
+	* 플레이어의 선택을 처리하는 함수
+	*/
+	bool InputChoice(PlayerChoice choice);
 
 public:
 	OddOrEven(ScenePtr previousScene, BlockBreakHandler& blockBreakHandler, std::function<void(BlockBreakHandler&)> gameOverFunc);

--- a/src/Combats/RockPaperScissor.cpp
+++ b/src/Combats/RockPaperScissor.cpp
@@ -7,7 +7,7 @@ std::string RPSBattleBackground[] = {
 };
 
 RockPaperScissor::RockPaperScissor(ScenePtr previousScene, BlockBreakHandler& blockBreakHandler, std::function<void(BlockBreakHandler&)> gameOverFunc)
-	: blockBreakHandler(blockBreakHandler), gameOverFunc(gameOverFunc) {
+	: inputLock(false), blockBreakHandler(blockBreakHandler), gameOverFunc(gameOverFunc) {
 
 	this->previousScene = previousScene;
 
@@ -56,28 +56,52 @@ void RockPaperScissor::EnterBattle() {
 
 	// 바위 선택
 	rock->setOnMouseCallback([&](auto, auto, auto, auto)->bool {
+#ifndef COMBAT_DEBUG
+		// 입력 불가능 상태라면 입력받지 않는다. 
+		if (inputLock == true) {
+			return true;
+		}
+#endif // !COMBAT_DEBUG
 		playerChoice = HandType::Rock;
 		computerChoice = MakeComputerChoice();
 		ShowChoices(playerChoice, computerChoice);
 		CompareChoices();
+		// 결과가 나오는 동안 입력을 잠근다. 
+		inputLock = true;
 		return true;
 		});
 
 	// 보 선택
 	paper->setOnMouseCallback([&](auto, auto, auto, auto)->bool {
+#ifndef COMBAT_DEBUG
+		// 입력 불가능 상태라면 입력받지 않는다. 
+		if (inputLock == true) {
+			return true;
+		}
+#endif // !COMBAT_DEBUG
 		playerChoice = HandType::Paper;
 		computerChoice = MakeComputerChoice();
 		ShowChoices(playerChoice, computerChoice);
 		CompareChoices();
+		// 결과가 나오는 동안 입력을 잠근다. 
+		inputLock = true;
 		return true;
 	});
 
 	// 가위 선택
 	scissor->setOnMouseCallback([&](auto, auto, auto, auto)->bool {
+#ifndef COMBAT_DEBUG
+		// 입력 불가능 상태라면 입력받지 않는다. 
+		if (inputLock == true) {
+			return true;
+		}
+#endif // !COMBAT_DEBUG
 		playerChoice = HandType::Scissors;
 		computerChoice = MakeComputerChoice();
 		ShowChoices(playerChoice, computerChoice);
 		CompareChoices();
+		// 결과가 나오는 동안 입력을 잠근다. 
+		inputLock = true;
 		return true;
 		});
 }
@@ -185,6 +209,8 @@ void RockPaperScissor::ShowChoices(HandType playerChoice, HandType computerChoic
 	choicesHideTimer->setOnTimerCallback([=](auto)->bool {
 		computerHand->hide();
 		playerHand->hide();
+		// 결과가 나오면 입력 잠금을 푼다. 
+		inputLock = false;
 		return true;
 		});
 	choicesHideTimer->start();

--- a/src/Combats/RockPaperScissor.cpp
+++ b/src/Combats/RockPaperScissor.cpp
@@ -1,11 +1,5 @@
 #include "RockPaperScissor.h"
 
-std::string RPSBattleBackground[] = {
-	CombatResource::BACKGROUND1,
-	CombatResource::BACKGROUND2,
-	CombatResource::BACKGROUND3
-};
-
 RockPaperScissor::RockPaperScissor(ScenePtr previousScene, BlockBreakHandler& blockBreakHandler, std::function<void(BlockBreakHandler&)> gameOverFunc)
 	: inputLock(false), blockBreakHandler(blockBreakHandler), gameOverFunc(gameOverFunc) {
 
@@ -56,54 +50,34 @@ void RockPaperScissor::EnterBattle() {
 
 	// 바위 선택
 	rock->setOnMouseCallback([&](auto, auto, auto, auto)->bool {
-#ifndef COMBAT_DEBUG
-		// 입력 불가능 상태라면 입력받지 않는다. 
-		if (inputLock == true) {
-			return true;
-		}
-#endif // !COMBAT_DEBUG
-		playerChoice = HandType::Rock;
-		computerChoice = MakeComputerChoice();
-		ShowChoices(playerChoice, computerChoice);
-		CompareChoices();
-		// 결과가 나오는 동안 입력을 잠근다. 
-		inputLock = true;
-		return true;
+		return InputChoice(HandType::Rock);
 		});
 
 	// 보 선택
 	paper->setOnMouseCallback([&](auto, auto, auto, auto)->bool {
-#ifndef COMBAT_DEBUG
-		// 입력 불가능 상태라면 입력받지 않는다. 
-		if (inputLock == true) {
-			return true;
-		}
-#endif // !COMBAT_DEBUG
-		playerChoice = HandType::Paper;
-		computerChoice = MakeComputerChoice();
-		ShowChoices(playerChoice, computerChoice);
-		CompareChoices();
-		// 결과가 나오는 동안 입력을 잠근다. 
-		inputLock = true;
-		return true;
+		return InputChoice(HandType::Paper);
 	});
 
 	// 가위 선택
 	scissor->setOnMouseCallback([&](auto, auto, auto, auto)->bool {
-#ifndef COMBAT_DEBUG
-		// 입력 불가능 상태라면 입력받지 않는다. 
-		if (inputLock == true) {
-			return true;
-		}
-#endif // !COMBAT_DEBUG
-		playerChoice = HandType::Scissors;
-		computerChoice = MakeComputerChoice();
-		ShowChoices(playerChoice, computerChoice);
-		CompareChoices();
-		// 결과가 나오는 동안 입력을 잠근다. 
-		inputLock = true;
-		return true;
+		return InputChoice(HandType::Scissors);
 		});
+}
+
+bool RockPaperScissor::InputChoice(HandType handType) {
+#ifndef COMBAT_DEBUG
+	// 입력 불가능 상태라면 입력받지 않는다. 
+	if (inputLock == true) {
+		return true;
+	}
+#endif // !COMBAT_DEBUG
+	playerChoice = handType;
+	computerChoice = MakeComputerChoice();
+	ShowChoices(playerChoice, computerChoice);
+	CompareChoices();
+	// 결과가 나오는 동안 입력을 잠근다. 
+	inputLock = true;
+	return true;
 }
 
 HandType RockPaperScissor::MakeComputerChoice(){

--- a/src/Combats/RockPaperScissor.h
+++ b/src/Combats/RockPaperScissor.h
@@ -68,6 +68,11 @@ private:
 	std::function<void(BlockBreakHandler&)> gameOverFunc;
 	BlockBreakHandler& blockBreakHandler;
 
+	/*
+	* 플레이어의 선택을 처리하는 함수
+	*/
+	bool InputChoice(HandType handType);
+
 public:
 	RockPaperScissor(ScenePtr previousScene, BlockBreakHandler& blockBreakHandler, std::function<void(BlockBreakHandler&)> gameOverFunc);
 

--- a/src/Combats/RockPaperScissor.h
+++ b/src/Combats/RockPaperScissor.h
@@ -61,6 +61,9 @@ private:
 	// 컴퓨터의 선택
 	HandType computerChoice = HandType::NoChoice;;
 
+	// 결과 표시 중에 플레이어의 입력을 막을 lock
+	bool inputLock;
+
 	// 게임 오버시 실행할 BlockBreakHandler의 멤버 함수 객체
 	std::function<void(BlockBreakHandler&)> gameOverFunc;
 	BlockBreakHandler& blockBreakHandler;

--- a/src/Combats/ShootTheMonster.cpp
+++ b/src/Combats/ShootTheMonster.cpp
@@ -58,45 +58,29 @@ void ShootTheMonster::EnterBattle() {
 		});
 
 	leftShoot->setOnMouseCallback([&](auto, auto, auto, auto)->bool {
-#ifndef COMBAT_DEBUG
-		// 입력 불가능 상태라면 입력받지 않는다. 
-		if (inputLock == true) {
-			return true;
-		}
-#endif // !COMBAT_DEBUG
-		playerShootDir = Direction::Left;
-		CompareDirection(playerShootDir, monsterPosition);
-		// 결과가 나오는 동안 입력을 잠근다. 
-		inputLock = true;
-		return true;
-		});
+		return InputChoice(Direction::Left);
+	});
 	centerShoot->setOnMouseCallback([&](auto, auto, auto, auto)->bool {
-#ifndef COMBAT_DEBUG
-		// 입력 불가능 상태라면 입력받지 않는다. 
-		if (inputLock == true) {
-			return true;
-		}
-#endif // !COMBAT_DEBUG
-		playerShootDir = Direction::Center;
-		CompareDirection(playerShootDir, monsterPosition);
-		// 결과가 나오는 동안 입력을 잠근다. 
-		inputLock = true;
-		return true;
-		});
+		return InputChoice(Direction::Center);
+	});
 	rightShoot->setOnMouseCallback([&](auto, auto, auto, auto)->bool {
-#ifndef COMBAT_DEBUG
-		// 입력 불가능 상태라면 입력받지 않는다. 
-		if (inputLock == true) {
-			return true;
-		}
-#endif // !COMBAT_DEBUG
-		playerShootDir = Direction::Right;
-		CompareDirection(playerShootDir, monsterPosition);
-		// 결과가 나오는 동안 입력을 잠근다. 
-		inputLock = true;
-		return true;
-		});
+		return InputChoice(Direction::Right);
+	});
 	monsterShowTimer->start();
+}
+
+bool ShootTheMonster::InputChoice(Direction direction) {
+#ifndef COMBAT_DEBUG
+	// 입력 불가능 상태라면 입력받지 않는다. 
+	if (inputLock == true) {
+		return true;
+	}
+#endif // !COMBAT_DEBUG
+	playerShootDir = direction;
+	CompareDirection(playerShootDir, monsterPosition);
+	// 결과가 나오는 동안 입력을 잠근다. 
+	inputLock = true;
+	return true;
 }
 
 void ShootTheMonster::ShowMonsterRandomly() {
@@ -189,13 +173,13 @@ void ShootTheMonster::ChangeMonsterToExplode(Direction direction) {
 
 	if (monsterPosition == direction) {
 		switch (monsterPosition) {
-		case Left:
+		case Direction::Left:
 			dirNum = 0;
 			break;
-		case Center:
+		case Direction::Center:
 			dirNum = 1;
 			break;
-		case Right:
+		case Direction::Right:
 			dirNum = 2;
 			break;
 		default:

--- a/src/Combats/ShootTheMonster.cpp
+++ b/src/Combats/ShootTheMonster.cpp
@@ -1,7 +1,7 @@
 #include "ShootTheMonster.h"
 
 ShootTheMonster::ShootTheMonster(ScenePtr previousScene, BlockBreakHandler& blockBreakHandler, std::function<void(BlockBreakHandler&)> gameOverFunc)
-	: blockBreakHandler(blockBreakHandler), gameOverFunc(gameOverFunc) {
+	: inputLock(false), blockBreakHandler(blockBreakHandler), gameOverFunc(gameOverFunc) {
 	this->previousScene = previousScene;
 	// 난수 생성 엔진 초기화
 	std::random_device rd;
@@ -52,22 +52,48 @@ void ShootTheMonster::EnterBattle() {
 		// 일정 시간이 지나면 다른 위치에서 보여줌
 		monsterShowTimer->set(ShootTheMonsterConfig::VISIBLE_TIME);
 		monsterShowTimer->start();
+		// 결과가 나오면 입력 잠금을 푼다. 
+		inputLock = false;
 		return true;
 		});
 
 	leftShoot->setOnMouseCallback([&](auto, auto, auto, auto)->bool {
+#ifndef COMBAT_DEBUG
+		// 입력 불가능 상태라면 입력받지 않는다. 
+		if (inputLock == true) {
+			return true;
+		}
+#endif // !COMBAT_DEBUG
 		playerShootDir = Direction::Left;
 		CompareDirection(playerShootDir, monsterPosition);
+		// 결과가 나오는 동안 입력을 잠근다. 
+		inputLock = true;
 		return true;
 		});
 	centerShoot->setOnMouseCallback([&](auto, auto, auto, auto)->bool {
+#ifndef COMBAT_DEBUG
+		// 입력 불가능 상태라면 입력받지 않는다. 
+		if (inputLock == true) {
+			return true;
+		}
+#endif // !COMBAT_DEBUG
 		playerShootDir = Direction::Center;
 		CompareDirection(playerShootDir, monsterPosition);
+		// 결과가 나오는 동안 입력을 잠근다. 
+		inputLock = true;
 		return true;
 		});
 	rightShoot->setOnMouseCallback([&](auto, auto, auto, auto)->bool {
+#ifndef COMBAT_DEBUG
+		// 입력 불가능 상태라면 입력받지 않는다. 
+		if (inputLock == true) {
+			return true;
+		}
+#endif // !COMBAT_DEBUG
 		playerShootDir = Direction::Right;
 		CompareDirection(playerShootDir, monsterPosition);
+		// 결과가 나오는 동안 입력을 잠근다. 
+		inputLock = true;
 		return true;
 		});
 	monsterShowTimer->start();

--- a/src/Combats/ShootTheMonster.h
+++ b/src/Combats/ShootTheMonster.h
@@ -71,6 +71,9 @@ private:
 	// 플레이어가 쏜 방향
 	Direction playerShootDir;
 
+	// 결과 표시 중에 플레이어의 입력을 막을 lock
+	bool inputLock;
+
 	// 게임 오버시 실행할 BlockBreakHandler의 멤버 함수 객체
 	std::function<void(BlockBreakHandler&)> gameOverFunc;
 	BlockBreakHandler& blockBreakHandler;

--- a/src/Combats/ShootTheMonster.h
+++ b/src/Combats/ShootTheMonster.h
@@ -17,7 +17,7 @@
 #include <bangtal>
 using namespace bangtal;
 
-enum Direction {
+enum class Direction {
 	Left,
 	Center,
 	Right
@@ -77,6 +77,11 @@ private:
 	// 게임 오버시 실행할 BlockBreakHandler의 멤버 함수 객체
 	std::function<void(BlockBreakHandler&)> gameOverFunc;
 	BlockBreakHandler& blockBreakHandler;
+
+	/*
+	* 플레이어의 선택을 처리하는 함수
+	*/
+	bool InputChoice(Direction direction);
 
 public:
 	ShootTheMonster(ScenePtr previousScene, BlockBreakHandler& blockBreakHandler, std::function<void(BlockBreakHandler&)> gameOverFunc);

--- a/src/Item.h
+++ b/src/Item.h
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <vector>
 #include "resource.h"
+#include "Cell.h"
 #include "MineField.h"
 #include <bangtal>
 
@@ -64,7 +65,7 @@ private:
 
 	// 스프레이 사용 후 인디케이터
 	ObjectPtr sprayUsedIndicator;
-	bool isSprayUsed;
+	bool isSprayUsed = false;
 
 	/*
 	* 해당 아이템의 itemCount 값에 따라 Item개수 이미지를 변경하는 함수
@@ -89,6 +90,26 @@ public:
 	*/ 
 	void ChangeHandByIndex(int index);
 	void ChangeHand(Hand hand);
+
+	/*
+	* detector 아이템을 선택한 상태로 셀을 클릭할 경우를 처리할 함수
+	*/
+	void UseDetector(int clickedCellRow, int clickedCellCol, std::vector<std::vector<CellPtr>>& cells, MineField& field);
+
+	/*
+	* spray 아이템을 선택할 시에 호출될 함수
+	*/
+	void SelectSpray();
+
+	/*
+	* spray 아이템을 사용할 때 호출되는 함수
+	*/
+	void UseSpray();
+
+	/*
+	* spray 아이템이 사용중인지 여부를 반환하는 함수
+	*/
+	bool getIsSprayUsed();
 
 	/*
 	* 현재 아이템의 개수를 확인하는 함수


### PR DESCRIPTION
1. spray 아이템의 작동을 구현하였습니다. 선택하면 사용하고 오른쪽 위에 표시됩니다. 표시된 상태에서 지뢰를 누르면 메세지와 함께 스프레이 표시가 사라집니다
2. 전투상황에서 결과가 표시되는 시간 동안 플레이어가 부적절한 입력을 할 수 있었던 것을 수정했습니다. 하지만 디버그시에는 빠른 결과 검증을 위해 입력을 받아들일 수 있도록 하였습니다. 
3. 몇몇 전투 상황 클래스에서 선택지 오브젝트의 콜백 함수를 하나로 통합하였습니다. 