### PR TITLE
탈출구 동작 및 게임 클리어 구현

### DIFF
--- a/src/MineField.cpp
+++ b/src/MineField.cpp
@@ -76,9 +76,9 @@ void MineField::Resize(int newRow, int newCol) {
         fieldData.push_back(rowData);
     }
 
-    // 지뢰의 개수는 전체 칸수의 1/4
+    // 지뢰의 개수는 전체 칸수의 1/6
     // 필요하다면 변경가능
-    mineCount = newRow * newCol / 4;
+    mineCount = newRow * newCol / 6;
 }
 
 void MineField::MountMine() {

--- a/src/MineSweeper.cpp
+++ b/src/MineSweeper.cpp
@@ -20,11 +20,7 @@ int main()
 	setGameOption(GameOption::GAME_OPTION_MESSAGE_BOX_BUTTON, false);
 	setGameOption(GameOption::GAME_OPTION_ROOM_TITLE, false);
 
-	// 게임 타이틀 및 스테이지 별 스크립트를 보이기 위한 방탈 장면
-	ScenePtr frontground = Scene::create("시작 화면", CombatResource::BACKGROUND1);
-	// 게임이 실행되는 방탈 장면
-	ScenePtr background = Scene::create("배경", BoardResource::BACKGROUND);
-	Stage stage(background, frontground);
+	Stage stage;
 
-	startGame(frontground);
+	startGame(stage.getFrontground());
 }

--- a/src/Stage.cpp
+++ b/src/Stage.cpp
@@ -1,8 +1,11 @@
 #include "Stage.h"
 
-Stage::Stage(ScenePtr bg, ScenePtr fg) {
-	background = bg;
-	frontground = fg;
+Stage::Stage() {
+	// 게임 타이틀 및 스테이지 별 스크립트를 보이기 위한 방탈 장면
+	frontground = Scene::create("시작 화면", CombatResource::BACKGROUND1);
+
+	// 게임이 실행되는 방탈 장면
+	background = Scene::create("배경", BoardResource::BACKGROUND);
 
 	// 지뢰찾기 보드 생성
 	board = new Board(background);
@@ -16,8 +19,22 @@ Stage::Stage(ScenePtr bg, ScenePtr fg) {
 		return true;
 	});
 
+	// background에서 보여줄 탈출하기 버튼
+	// 주어진 조건을 만족할 때만 보이기 위해 숨긴다.
+	escapeButton = Object::create(CellResource::EMPTY, background, 0, 690);
+	escapeButton->setOnMouseCallback([&](auto object, int x, int y, auto action)->bool {
+		board->setBoardStatus(BoardStatus::Clear);
+		escapeButton->hide();
+		return true;
+		});
+	escapeButton->hide();
+
 	// 스테이지의 이벤트 핸들러가 동작한다.
 	EventHandler();
+}
+
+ScenePtr Stage::getFrontground() {
+	return frontground;
 }
 
 void Stage::EventHandler() {
@@ -25,6 +42,12 @@ void Stage::EventHandler() {
 	boardStatusChecker = Timer::create(REFRESH_TIME);
 	boardStatusChecker->setOnTimerCallback([&](auto)->bool {
 		// Playing -> 이벤트 없음
+		// Escape -> 탈출하기 버튼 보이기
+		if (board->getBoardStatus() == BoardStatus::Escape) {
+			board->setBoardStatus(BoardStatus::Playing);
+			escapeButton->show();
+			showMessage("탈출구를 찾았습니다! 스테이지를 벗어나고 싶으면 탈출하기 버튼을 누르세요.\n지금 탈출하지 않고 남아있는 아이템을 획득하기 위해 게임을 계속 진행할 수 있습니다.");
+		}
 		// Claer -> 다음 스테이지
 		if (board->getBoardStatus() == BoardStatus::Clear) {
 			NextStage();
@@ -32,7 +55,7 @@ void Stage::EventHandler() {
 		// GameOver -> 보드 초기화?
 		if (board->getBoardStatus() == BoardStatus::GameOver) {
 			// ** 디버그용 ** 게임 종료
-			std::cout << "게임 오버!";
+			std::cout << "Game over!";
 			endGame();
 		}
 		boardStatusChecker->set(REFRESH_TIME);
@@ -44,18 +67,30 @@ void Stage::EventHandler() {
 }
 
 void Stage::NextStage() {
-	// 다음 스테이지로 넘어갈 때 보여줄 스크립트를 갱신한다.
-	// script->setImage();
-
-	// 스크립트를 가지고 있는 front 장면으로 입장한다.
-	frontground->enter();
-
 	// 스테이지 레벨을 갱신한다.
 	currentStageLevel++;
 
-	// 다음 지뢰찾기 보드로 갱신한다.
-	int row = board->getRow();
-	int col = board->getCol();
-	board->RefreshBoard(row + 2, col + 4);
+	// 정해진 스테이지를 모두 클리어했다면 게임을 클리어한 것이다.
+	if (currentStageLevel == STAGE_COUNT) {
+		// ** 디버그용 ** 게임 종료
+		std::cout << "Game Clear!";
+		endGame();
+	}
+
+	// 아직 클리어할 스테이지가 남았다면 게임을 진행한다.
+	else {
+		// 다음 스테이지로 넘어갈 때 보여줄 스크립트를 갱신한다.
+		// script->setImage();
+
+		// 스크립트를 가지고 있는 front 장면으로 입장한다.
+		frontground->enter();
+
+		// 다음 지뢰찾기 보드로 갱신한다.
+		int row = board->getRow();
+		int col = board->getCol();
+		board->RefreshBoard(row + 2, col + 4);
+
+		// 다음 지뢰찾기 보드의 배경을 갱신한다.
+	}
 }
 

--- a/src/Stage.h
+++ b/src/Stage.h
@@ -26,6 +26,9 @@ private:
 
 	// 게임 타이틀 및 스테이지 별 스크립트를 나타내는 방탈 오브젝트
 	ObjectPtr script;
+
+	// 탈출하기 버튼을 나타내는 방탈 오브젝트
+	ObjectPtr escapeButton;
 	
 	// 지뢰찾기 보드
 	Board* board;
@@ -37,7 +40,10 @@ private:
 	TimerPtr boardStatusChecker;
 
 public:
-	Stage(ScenePtr background, ScenePtr frontground);
+	Stage();
+
+	// 시작 장면을 반환하는 함수
+	ScenePtr getFrontground();
 
 	// 보드 진행 상황 변경시 적절한 이벤트를 발생하는 함수
 	void EventHandler();


### PR DESCRIPTION
1. 메인 함수에서 스테이지만을 생성하도록 수정되었습니다.
2. 지뢰의 비율이 4분의 1에서 6분의 1로 수정되었습니다.
3. 탈출구를 발견하면 지금 당장 탈출하거나 남은 아이템을 찾고 갈 수 있도록 수정되었습니다.
4. 정해진 개수의 스테이지를 모두 클리어하면 게임이 종료되도록 하였습니다.