### PR TITLE
전투 상황 타이머 오류 수정

### DIFF
--- a/src/BlockBreakHandler.cpp
+++ b/src/BlockBreakHandler.cpp
@@ -66,7 +66,7 @@ void BlockBreakHandler::EnterRandomCombat(int curRow, int curCol) {
 	}
 	std::random_device rd;
 	std::mt19937 gen(rd());
-	std::uniform_int_distribution<int> dis(0, 4);
+	std::uniform_int_distribution<int> dis(2, 2);
 
 	// 동적 바인딩을 이용해 무작위로 전투상황 진입
 	switch (dis(gen)) {

--- a/src/BlockBreakHandler.cpp
+++ b/src/BlockBreakHandler.cpp
@@ -66,7 +66,7 @@ void BlockBreakHandler::EnterRandomCombat(int curRow, int curCol) {
 	}
 	std::random_device rd;
 	std::mt19937 gen(rd());
-	std::uniform_int_distribution<int> dis(2, 2);
+	std::uniform_int_distribution<int> dis(0, 4);
 
 	// 동적 바인딩을 이용해 무작위로 전투상황 진입
 	switch (dis(gen)) {

--- a/src/Combat.h
+++ b/src/Combat.h
@@ -22,4 +22,5 @@ public:
 	*/
 	virtual void EnterBattle() = 0;
 
+	virtual ~Combat() { };
 };

--- a/src/Combats/DiceMatching.cpp
+++ b/src/Combats/DiceMatching.cpp
@@ -53,7 +53,9 @@ void DiceMatching::EnterBattle(){
 
 	resultDelayTimer = Timer::create(DiceMatchingConfig::VISIBLE_TIME);
 	resultDelayTimer->setOnTimerCallback([&](auto)->bool {
-		diceAnimation->start();
+		if (diceAnimation != nullptr) {
+			diceAnimation->start();
+		}
 		// 결과가 나오면 입력 잠금을 푼다. 
 		inputLock = false;
 		return true;
@@ -150,7 +152,7 @@ void DiceMatching::CompareChoice() {
 		monsters.pop_back();
 		if (monsters.size() == 0) {
 			showMessage("몬스터들을 물리쳤습니다!");
-			diceAnimation->stop();
+			diceAnimation.reset();
 			this->previousScene->enter();
 		}
 		else {

--- a/src/Combats/DiceMatching.cpp
+++ b/src/Combats/DiceMatching.cpp
@@ -152,7 +152,6 @@ void DiceMatching::CompareChoice() {
 		monsters.pop_back();
 		if (monsters.size() == 0) {
 			showMessage("몬스터들을 물리쳤습니다!");
-			diceAnimation.reset();
 			this->previousScene->enter();
 		}
 		else {
@@ -171,4 +170,11 @@ void DiceMatching::CompareChoice() {
 			showMessage("몬스터가 이겼습니다...");
 		}
 	}
+}
+
+DiceMatching::~DiceMatching() {
+	diceAnimation->stop();
+	diceAnimation.reset();
+	resultDelayTimer->stop();
+	resultDelayTimer.reset();
 }

--- a/src/Combats/DiceMatching.h
+++ b/src/Combats/DiceMatching.h
@@ -69,6 +69,7 @@ private:
 
 public:
 	DiceMatching(ScenePtr previousScene, BlockBreakHandler& blockBreakHandler, std::function<void(BlockBreakHandler&)> gameOverFunc);
+	~DiceMatching();
 
 	/*
 	* 전투에 진입하는 함수

--- a/src/Combats/DiceRolling.cpp
+++ b/src/Combats/DiceRolling.cpp
@@ -71,8 +71,10 @@ void DiceRolling::EnterBattle() {
 	
 	resultDelayTimer = Timer::create(DiceRollingConfig::VISIBLE_TIME);
 	resultDelayTimer->setOnTimerCallback([&](auto)->bool {
-		computerDiceAnimation->start();
-		playerDiceAnimation->start();
+		if (computerDiceAnimation != nullptr && playerDiceAnimation != nullptr) {
+			computerDiceAnimation->start();
+			playerDiceAnimation->start();
+		}
 		// 결과가 나오면 입력 잠금을 푼다. 
 		inputLock = false;
 		return true;
@@ -142,7 +144,9 @@ void DiceRolling::CompareDice() {
 		if (monsters.size() == 0) {
 			showMessage("몬스터들을 물리쳤습니다!");
 			computerDiceAnimation->stop();
+			computerDiceAnimation.reset();
 			playerDiceAnimation->stop();
+			playerDiceAnimation.reset();
 			this->previousScene->enter();
 		}
 		else {

--- a/src/Combats/DiceRolling.cpp
+++ b/src/Combats/DiceRolling.cpp
@@ -143,10 +143,6 @@ void DiceRolling::CompareDice() {
 		monsters.pop_back();
 		if (monsters.size() == 0) {
 			showMessage("몬스터들을 물리쳤습니다!");
-			computerDiceAnimation->stop();
-			computerDiceAnimation.reset();
-			playerDiceAnimation->stop();
-			playerDiceAnimation.reset();
 			this->previousScene->enter();
 		}
 		else {
@@ -167,4 +163,13 @@ void DiceRolling::CompareDice() {
 			showMessage("몬스터가 이겼습니다...");
 		}
 	}
+}
+
+DiceRolling::~DiceRolling() {
+	computerDiceAnimation->stop();
+	computerDiceAnimation.reset();
+	playerDiceAnimation->stop();
+	playerDiceAnimation.reset();
+	resultDelayTimer->stop();
+	resultDelayTimer.reset();
 }

--- a/src/Combats/DiceRolling.h
+++ b/src/Combats/DiceRolling.h
@@ -65,6 +65,7 @@ private:
 
 public:
 	DiceRolling(ScenePtr previousScene, BlockBreakHandler& blockBreakHandler, std::function<void(BlockBreakHandler&)> gameOverFunc);
+	~DiceRolling();
 
 	/*
 	* 전투에 진입하는 함수

--- a/src/Combats/OddOrEven.cpp
+++ b/src/Combats/OddOrEven.cpp
@@ -139,7 +139,6 @@ void OddOrEven::CompareChoice() {
 		monsters.pop_back();
 		if (monsters.size() == 0) {
 			showMessage("몬스터들을 물리쳤습니다!");
-			diceAnimation.reset();
 			this->previousScene->enter();
 		}
 		else {
@@ -158,4 +157,11 @@ void OddOrEven::CompareChoice() {
 			showMessage("몬스터가 이겼습니다...");
 		}
 	}
+}
+
+OddOrEven::~OddOrEven() {
+	diceAnimation->stop();
+	diceAnimation.reset();
+	resultDelayTimer->stop();
+	resultDelayTimer.reset();
 }

--- a/src/Combats/OddOrEven.cpp
+++ b/src/Combats/OddOrEven.cpp
@@ -53,7 +53,9 @@ void OddOrEven::EnterBattle() {
 
 	resultDelayTimer = Timer::create(OddOrEvenConfig::VISIBLE_TIME);
 	resultDelayTimer->setOnTimerCallback([&](auto)->bool {
-		diceAnimation->start();
+		if (diceAnimation != nullptr) {
+			diceAnimation->start();
+		}
 		// 결과가 나오면 입력 잠금을 푼다. 
 		inputLock = false;
 		return true;
@@ -137,7 +139,7 @@ void OddOrEven::CompareChoice() {
 		monsters.pop_back();
 		if (monsters.size() == 0) {
 			showMessage("몬스터들을 물리쳤습니다!");
-			diceAnimation->stop();
+			diceAnimation.reset();
 			this->previousScene->enter();
 		}
 		else {

--- a/src/Combats/OddOrEven.h
+++ b/src/Combats/OddOrEven.h
@@ -81,6 +81,7 @@ private:
 
 public:
 	OddOrEven(ScenePtr previousScene, BlockBreakHandler& blockBreakHandler, std::function<void(BlockBreakHandler&)> gameOverFunc);
+	~OddOrEven();
 
 	/*
 	* 전투에 진입하는 함수

--- a/src/Combats/ShootTheMonster.cpp
+++ b/src/Combats/ShootTheMonster.cpp
@@ -146,8 +146,6 @@ void ShootTheMonster::CompareDirection(Direction playerDir, Direction monsterDir
 		monsterRemainCount--;
 		if (monsterRemainCount == 0) {
 			showMessage("몬스터들을 모두 물리쳤습니다!");
-			monsterShowTimer->stop();
-			monsterShowTimer.reset();
 			this->previousScene->enter();
 		}
 		else {
@@ -155,14 +153,10 @@ void ShootTheMonster::CompareDirection(Direction playerDir, Direction monsterDir
 		}
 	}
 	else if (opportunity.size() < monsterRemainCount) {
-		monsterShowTimer->stop();
-		monsterShowTimer.reset();
 		gameOverFunc(blockBreakHandler);
 	}
 	else {
 		if (opportunity.size() == 0) {
-			monsterShowTimer->stop();
-			monsterShowTimer.reset();
 			gameOverFunc(blockBreakHandler);
 		}
 		else {
@@ -200,4 +194,9 @@ void ShootTheMonster::ChangeMonsterToExplode(Direction direction) {
 		}
 		return true;
 		});
+}
+
+ShootTheMonster::~ShootTheMonster() {
+	monsterShowTimer->stop();
+	monsterShowTimer.reset();
 }

--- a/src/Combats/ShootTheMonster.cpp
+++ b/src/Combats/ShootTheMonster.cpp
@@ -147,6 +147,7 @@ void ShootTheMonster::CompareDirection(Direction playerDir, Direction monsterDir
 		if (monsterRemainCount == 0) {
 			showMessage("몬스터들을 모두 물리쳤습니다!");
 			monsterShowTimer->stop();
+			monsterShowTimer.reset();
 			this->previousScene->enter();
 		}
 		else {
@@ -155,11 +156,13 @@ void ShootTheMonster::CompareDirection(Direction playerDir, Direction monsterDir
 	}
 	else if (opportunity.size() < monsterRemainCount) {
 		monsterShowTimer->stop();
+		monsterShowTimer.reset();
 		gameOverFunc(blockBreakHandler);
 	}
 	else {
 		if (opportunity.size() == 0) {
 			monsterShowTimer->stop();
+			monsterShowTimer.reset();
 			gameOverFunc(blockBreakHandler);
 		}
 		else {
@@ -191,8 +194,10 @@ void ShootTheMonster::ChangeMonsterToExplode(Direction direction) {
 	}
 
 	monsterExplodeTimer->setOnTimerCallback([&](auto)->bool {
-		monsters[dirNum]->setImage(CombatResource::MONSTER3);
-		monsterShowTimer->start();
+		if (monsterShowTimer != nullptr) {
+			monsters[dirNum]->setImage(CombatResource::MONSTER3);
+			monsterShowTimer->start();
+		}
 		return true;
 		});
 }

--- a/src/Combats/ShootTheMonster.h
+++ b/src/Combats/ShootTheMonster.h
@@ -85,6 +85,7 @@ private:
 
 public:
 	ShootTheMonster(ScenePtr previousScene, BlockBreakHandler& blockBreakHandler, std::function<void(BlockBreakHandler&)> gameOverFunc);
+	~ShootTheMonster();
 
 	/*
 	* 전투에 진입하는 함수


### PR DESCRIPTION
1. 전투 상황 객체가 소멸되었을 때, 전투 상황 안에서 일정 간격으로 돌아가는 타이머가 소멸된 자기 자신을 다시 참조하여 nullptr 오류가 발생하는 문제를 수정했습니다. 이제 전투 상황 객체가 소멸하는 시점에서 타이머도 정지합니다. 