### PR TITLE
게임 재시작 구현, 아이템 사용 후 빈 칸을 선택한 채로 블럭이 깨지던 오류 수정

### DIFF
--- a/src/BlockBreakHandler.cpp
+++ b/src/BlockBreakHandler.cpp
@@ -164,7 +164,9 @@ void BlockBreakHandler::RefreshBoardStatus(int curRow, int curCol) {
 }
 
 void BlockBreakHandler::StopCheckNewCellOpened() {
-	refreshTimer->stop();
+	if (this != nullptr && refreshTimer != nullptr) {
+		refreshTimer->stop();
+	}
 }
 
 BlockBreakHandler::~BlockBreakHandler() {

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -14,6 +14,13 @@ Board::Board(ScenePtr bg, int initLifeCount, bool& isGameMute) : isGameMute(isGa
 	InitItem(initLifeCount);
 }
 
+Board::~Board() {
+	OnBlockBreak.reset();
+	boardCount = 0;
+	background.reset();
+	item.reset();
+}
+
 
 void Board::RefreshBoard(int newRow, int newCol, int stageNum) {
 	// 반드시 클리어 시에만 이 함수를 호출할 것!
@@ -50,8 +57,7 @@ void Board::Clear() {
 
 void Board::GenerateNewBoard(int newRow, int newCol, int stageNum) {
 	if (row != 0 || col != 0) {
-		std::cout << "A regeneration of the board that did not clear data has occurred!" << std::endl;
-		exit(1);
+		Clear();
 	}
 
 	row = newRow;
@@ -113,6 +119,12 @@ void Board::GenerateNewBoard(int newRow, int newCol, int stageNum) {
 	OnBlockBreak->CheckNewCellOpened();
 }
 
+void Board::InitBoard(int initLifeCount) {
+	Clear();
+	InitItem(initLifeCount);
+	combatCount = 0;
+}
+
 void Board::InitItem(int initLifeCount) {
 	if (item != nullptr) {
 		item.reset();
@@ -140,4 +152,3 @@ void Board::setBoardStatus(BoardStatus status) {
 int Board::getCombatCount() {
 	return combatCount;
 }
-

--- a/src/Board.h
+++ b/src/Board.h
@@ -60,6 +60,7 @@ private:
 
 public:
 	Board(ScenePtr bg, int initLifeCount, bool& isGameMute);
+	~Board();
 
 	/*
 	* 보드를 주어진 크기로 초기화하고 생성하는 함수
@@ -75,6 +76,11 @@ public:
 	* 보드를 주어진 크기로 새로 생성하는 함수
 	*/ 
 	void GenerateNewBoard(int newRow, int newCol, int stageNum);
+
+	/*
+	* 보드의 모든 데이터를 초기화하는 함수
+	*/
+	void InitBoard(int initLifeCount);
 
 	/*
 	* 아이템 초기화 함수

--- a/src/Item.cpp
+++ b/src/Item.cpp
@@ -106,6 +106,7 @@ void Item::ChangeHandByIndex(int index) {
 		SelectSpray();
 		break;
 	default:
+		currentHand = Hand::None;
 		break;
 	}
 

--- a/src/Item.h
+++ b/src/Item.h
@@ -34,6 +34,8 @@ enum class Hand {
 	Detector,
 	//스프레이 (몬스터와의 전투를 1번 회피)
 	Spray,
+	
+	None,
 };
 
 class Item {

--- a/src/MineSweeper.cpp
+++ b/src/MineSweeper.cpp
@@ -20,5 +20,6 @@ int main()
 	setGameOption(GameOption::GAME_OPTION_MESSAGE_BOX_BUTTON, false);
 	setGameOption(GameOption::GAME_OPTION_ROOM_TITLE, false);
 	Stage stage;
+	stage.MakeTitle();
 	stage.StartGame();
 }

--- a/src/Stage.h
+++ b/src/Stage.h
@@ -61,7 +61,7 @@ private:
 	ObjectPtr escapeButton;
 
 	// 지뢰찾기 보드
-	Board* board;
+	std::shared_ptr<Board> board;
 
 	// 클리어한 스테이지의 개수
 	int stageNum = 0;
@@ -69,14 +69,17 @@ private:
 	// 보드 진행 상황을 체크할 타이머
 	TimerPtr boardStatusChecker;
 
-	// 엔딩 스트립트
-	ObjectPtr endingScript;
+	// 엔딩에서 보여줄 버튼
+	ObjectPtr goToTitleButton;
+	ObjectPtr gameEndButton;
 
 public:
 	Stage();
 
-	// tile 장면과 title 장면이 가지는 방탈 오브젝트들을 초기화하는 함수
 	void StartGame();
+
+	// tile 장면과 title 장면이 가지는 방탈 오브젝트들을 초기화하는 함수
+	void MakeTitle();
 
 	// scriptBackground 장면과 scriptBackground 장면이 가지는 방탈 오브젝트들을 초기화하는 함수
 	void ShowScript(int stageNum);

--- a/src/resource.h
+++ b/src/resource.h
@@ -20,7 +20,8 @@ namespace EndingResource {
 	constexpr auto HAPPY_END = "image/Background/Ending1.png";
 	constexpr auto BAD_END = "image/Background/Ending2.png";
 
-	constexpr auto END_BUTTON = "image/script/end.png";
+	constexpr auto END_BUTTON = "image/ButtonUI/ExitGame.png";
+	constexpr auto GO_TO_TITLE_BUTTON = "image/ButtonUI/GoToTitle.png";
 
 	constexpr auto HAPPY_END_MUSIC = "music/HappyEnding.mp3";
 	constexpr auto BAD_END_MUSIC = "music/BadEnding.mp3";


### PR DESCRIPTION
1. 게임 재시작을 구현했습니다. 다음과 같은 상황에서 게임이 재시작 됩니다. 
 - 남아있는 목숨이 없는 경우
 - 엔딩에서 재시작 버튼을 클릭할 경우
2. 아이템을 사용한 후, 빈 아이템 칸을 선택하고 블럭을 클릭하면 현재 아이템이 곡괭이가 아님에도 불구하고 블럭이 깨지던 오류를 수정했습니다. 